### PR TITLE
Add --config flag and AST_GREP_CONFIG env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Add to your Claude Desktop MCP configuration:
 }
 ```
 
+### Custom ast-grep Configuration
+
+The MCP server supports using a custom `sgconfig.yaml` file to configure ast-grep behavior.
+See the [ast-grep configuration documentation](https://ast-grep.github.io/guide/project/project-config.html) for details on the config file format.
+
+You can provide the config file in two ways (in order of precedence):
+
+1. **Command-line argument**: `--config /path/to/sgconfig.yaml`
+2. **Environment variable**: `AST_GREP_CONFIG=/path/to/sgconfig.yaml`
+
 ## Usage
 
 This repository includes comprehensive ast-grep rule documentation in [ast-grep.mdc](https://github.com/ast-grep/ast-grep-mcp/blob/main/ast-grep.mdc). The documentation covers all aspects of writing effective ast-grep rules, from simple patterns to complex multi-condition searches.


### PR DESCRIPTION
This PR adds support for providing a custom sgconfig.yaml file to the mcp server, either via a --config CLI argument or via a `AST_GREP_CONFIG`. The env var is esp. helpful when checking .mcp.json files into git without needing to hardcode a config path.

Being able to specify a custom config file is useful when e.g. needing to registering custom languages with ast-grep.

The mcp server now also supports a `--help` flag which results in:
```
> python main.py --help
usage: python main.py [-h] [--config PATH]

ast-grep MCP Server - Provides structural code search capabilities via Model Context Protocol

options:
  -h, --help     show this help message and exit
  --config PATH  Path to sgconfig.yaml file for customizing ast-grep behavior (language mappings, rule directories, etc.)

environment variables:
  AST_GREP_CONFIG    Path to sgconfig.yaml file (overridden by --config flag)

For more information, see: https://github.com/ast-grep/ast-grep-mcp
```