### PR TITLE
Harden MCP search boundaries and expose server metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,12 @@ jobs:
 
     - name: Install ast-grep
       run: |
-        npm install -g @ast-grep/cli
+        npm install -g @ast-grep/cli@0.44.1
         ast-grep --version
 
     - name: Install dependencies
       run: |
-        uv sync --all-extras --dev
+        uv sync --frozen --all-extras --dev
 
     - name: Lint with ruff
       run: |
@@ -55,11 +55,14 @@ jobs:
     - name: Format check with ruff
       run: |
         uv run ruff format --check .
-      continue-on-error: true  # TODO
 
     - name: Type check with mypy
       run: |
         uv run mypy main.py
+
+    - name: Smoke test packaged entry point
+      run: |
+        uv run ast-grep-server --help
 
     - name: Run unit tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ wheels/
 
 # MyPy. Ruff, PyTest cache folders
 .*_cache/
+.coverage
+.coverage.*
 
 # Virtual environments
 .venv

--- a/README.md
+++ b/README.md
@@ -1,243 +1,125 @@
 # ast-grep MCP Server
 
-An experimental [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that provides AI assistants with powerful structural code search capabilities using [ast-grep](https://ast-grep.github.io/).
+A bounded, read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for structural code inspection with [ast-grep](https://ast-grep.github.io/).
 
-## Overview
+The server is designed for model-facing exploration: inspect syntax, test a rule against a snippet, then search a deliberately constrained project scope. It does not expose rewriting or editing tools. Exhaustive scans and authorized rewrites remain CLI workflows.
 
-This MCP server enables AI assistants (like Cursor, Claude Desktop, etc.) to search and analyze codebases using Abstract Syntax Tree (AST) pattern matching rather than simple text-based search. By leveraging ast-grep's structural search capabilities, AI can:
+## Requirements
 
-- Find code patterns based on syntax structure, not just text matching
-- Search for specific programming constructs (functions, classes, imports, etc.)
-- Write and test complex search rules using YAML configuration
-- Debug and visualize AST structures for better pattern development
+- Python 3.13 or newer
+- [uv](https://docs.astral.sh/uv/)
+- ast-grep 0.44.1 for the tested integration contract
 
-## Prerequisites
-
-1. **Install ast-grep**: Follow [ast-grep installation guide](https://ast-grep.github.io/guide/quick-start.html#installation)
-   ```bash
-   # macOS
-   brew install ast-grep
-   nix-shell -p ast-grep
-   cargo install ast-grep --locked
-   ```
-
-2. **Install uv**: Python package manager
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   ```
-
-3. **MCP-compatible client**: Such as Cursor, Claude Desktop, or other MCP clients
-
-## Installation
-
-1. Clone this repository:
-   ```bash
-   git clone https://github.com/ast-grep/ast-grep-mcp.git
-   cd ast-grep-mcp
-   ```
-
-2. Install dependencies:
-   ```bash
-   uv sync
-   ```
-
-3. Verify ast-grep installation:
-   ```bash
-   ast-grep --version
-   ```
-
-## Running with `uvx`
-
-You can run the server directly from GitHub using `uvx`:
+Install the tested ast-grep CLI with npm:
 
 ```bash
-uvx --from git+https://github.com/ast-grep/ast-grep-mcp ast-grep-server
+npm install --global @ast-grep/cli@0.44.1
+ast-grep --version
 ```
 
-This is useful for quickly trying out the server without cloning the repository.
+## Run from an immutable fork revision
 
-## Configuration
+Pin MCP consumers to a commit SHA:
 
-### For Cursor
+```bash
+uvx \
+  --from git+https://github.com/jmclaughlin724/ast-grep-mcp@<commit-sha> \
+  ast-grep-server \
+  --ast-grep /absolute/path/to/ast-grep \
+  --allowed-root /absolute/path/to/project \
+  --config /absolute/path/to/project/sgconfig.yml \
+  --forbid-regex-rules
+```
 
-Add to your MCP settings (usually in `.cursor-mcp/settings.json`):
+`--allowed-root` is repeatable. When omitted, it defaults to the process working directory. Every project, search path, symlink target, and config path is resolved before use and must remain inside an allowed root.
+
+## Server options
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--ast-grep PATH` | `ast-grep` | Resolve the exact CLI instead of trusting a later `PATH` lookup. |
+| `--allowed-root PATH` | process working directory | Permit searches only inside this real path; repeat to add roots. |
+| `--config PATH` | unset | Use one contained `sgconfig.yml`. |
+| `--command-timeout SECONDS` | `30` | Bound every ast-grep subprocess. |
+| `--default-max-results COUNT` | `50` | Set the finite result limit used when a tool call omits it. |
+| `--max-results-cap COUNT` | `500` | Cap caller-selected limits; values above 500 are rejected. |
+| `--forbid-regex-rules` | off | Reject inline YAML containing ast-grep `regex` matcher keys. |
+| `--transport` | `stdio` | Select `stdio`, `sse`, or `streamable-http`. |
+
+Equivalent environment variables exist for the ast-grep executable, config, timeout, result limits, and regex-rule policy. Use command arguments in checked-in MCP launchers so the effective security contract stays visible.
+
+## Tools
+
+All tools advertise these MCP annotations:
+
+- read-only
+- non-destructive
+- idempotent
+- closed-world
+
+### `dump_syntax_tree`
+
+Inspect how ast-grep parses code or a query pattern. Use `cst` for concrete target syntax and `pattern` while developing a query.
+
+### `test_match_code_rule`
+
+Test YAML with `id`, `language`, and `rule` fields against a code snippet. A valid negative probe returns an empty match list instead of an error.
+
+### `find_code`
+
+Search with a complete structural pattern and an explicit language. The tool accepts:
+
+- `project_folder`
+- relative `paths`
+- `include_globs`
+- `exclude_globs`
+- finite `max_results`
+- `output_format` (`text` or `json`)
+
+Pattern searches are compiled into inline rules and run with `ast-grep scan --max-results <limit+1>`. This stops work early and reports truncation without scanning the entire tree.
+
+### `find_code_by_rule`
+
+Search with one or more inline YAML rules using the same path, glob, result-limit, and output controls.
+
+### `get_server_info`
+
+Report the fork version, resolved ast-grep executable and version, config path, allowed roots, command timeout, effective result limits, and regex-rule policy.
+
+## Search results
+
+Compact text is the default model-facing format:
+
+```text
+Found 2 matches (limit 2; additional matches exist):
+
+src/example.ts:4
+loadData()
+```
+
+JSON results have one stable envelope:
 
 ```json
 {
-  "mcpServers": {
-    "ast-grep": {
-      "command": "uv",
-      "args": ["--directory", "/absolute/path/to/ast-grep-mcp", "run", "main.py"],
-      "env": {}
-    }
-  }
+  "matches": [],
+  "returned": 0,
+  "truncated": false,
+  "limit": 50
 }
 ```
 
-### For Claude Desktop
+The server never offers zero or unlimited searches. It returns project-relative match paths and rejects results that resolve outside the selected project.
 
-Add to your Claude Desktop MCP configuration:
+## Development
 
-```json
-{
-  "mcpServers": {
-    "ast-grep": {
-      "command": "uv",
-      "args": ["--directory", "/absolute/path/to/ast-grep-mcp", "run", "main.py"],
-      "env": {}
-    }
-  }
-}
+```bash
+uv sync --frozen --all-extras --dev
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy main.py
+uv run pytest
 ```
 
-### Custom ast-grep Configuration
+The integration suite launches the real STDIO server, negotiates MCP, inspects the exact tool catalog and annotations, calls metadata and search tools, and verifies ast-grep 0.44.1.
 
-The MCP server supports using a custom `sgconfig.yaml` file to configure ast-grep behavior.
-See the [ast-grep configuration documentation](https://ast-grep.github.io/guide/project/project-config.html) for details on the config file format.
-
-You can provide the config file in two ways (in order of precedence):
-
-1. **Command-line argument**: `--config /path/to/sgconfig.yaml`
-2. **Environment variable**: `AST_GREP_CONFIG=/path/to/sgconfig.yaml`
-
-## Usage
-
-This repository includes comprehensive ast-grep rule documentation in [ast-grep.mdc](https://github.com/ast-grep/ast-grep-mcp/blob/main/ast-grep.mdc). The documentation covers all aspects of writing effective ast-grep rules, from simple patterns to complex multi-condition searches.
-
-You can add it to your cursor rule or Claude.md, and attach it when you need AI agent to create ast-grep rule for you.
-
-The prompt will ask LLM to use MCP to create, verify and improve the rule it creates.
-
-## Features
-
-The server provides four main tools for code analysis:
-
-### 🔍 `dump_syntax_tree`
-Visualize the Abstract Syntax Tree structure of code snippets. Essential for understanding how to write effective search patterns.
-
-**Use cases:**
-- Debug why a pattern isn't matching
-- Understand the AST structure of target code
-- Learn ast-grep pattern syntax
-
-### 🧪 `test_match_code_rule`
-Test ast-grep YAML rules against code snippets before applying them to larger codebases.
-
-**Use cases:**
-- Validate rules work as expected
-- Iterate on rule development
-- Debug complex matching logic
-
-### 🎯 `find_code`
-Search codebases using simple ast-grep patterns for straightforward structural matches.
-
-**Parameters:**
-- `max_results`: Limit number of complete matches returned (default: unlimited)
-- `output_format`: Choose between `"text"` (default, ~75% fewer tokens) or `"json"` (full metadata)
-
-**Text Output Format:**
-```
-Found 2 matches:
-
-path/to/file.py:10-15
-def example_function():
-    # function body
-    return result
-
-path/to/file.py:20-22
-def another_function():
-    pass
-```
-
-**Use cases:**
-- Find function calls with specific patterns
-- Locate variable declarations
-- Search for simple code constructs
-
-### 🚀 `find_code_by_rule`
-Advanced codebase search using complex YAML rules that can express sophisticated matching criteria.
-
-**Parameters:**
-- `max_results`: Limit number of complete matches returned (default: unlimited)
-- `output_format`: Choose between `"text"` (default, ~75% fewer tokens) or `"json"` (full metadata)
-
-**Use cases:**
-- Find nested code structures
-- Search with relational constraints (inside, has, precedes, follows)
-- Complex multi-condition searches
-
-
-## Usage Examples
-
-### Basic Pattern Search
-
-Use Query:
-
-> Find all console.log statements
-
-AI will generate rules like:
-
-```yaml
-id: find-console-logs
-language: javascript
-rule:
-  pattern: console.log($$$)
-```
-
-### Complex Rule Example
-
-User Query:
-> Find async functions that use await
-
-AI will generate rules like:
-
-```yaml
-id: async-with-await
-language: javascript
-rule:
-  all:
-    - kind: function_declaration
-    - has:
-        pattern: async
-    - has:
-        pattern: await $EXPR
-        stopBy: end
-```
-
-## Supported Languages
-
-ast-grep supports many programming languages including:
-- JavaScript/TypeScript
-- Python
-- Rust
-- Go
-- Java
-- C/C++
-- C#
-- And many more...
-
-For a complete list of built-in supported languages, see the [ast-grep language support documentation](https://ast-grep.github.io/reference/languages.html).
-
-You can also add support for custom languages through the `sgconfig.yaml` configuration file. See the [custom language guide](https://ast-grep.github.io/guide/project/project-config.html#languagecustomlanguage) for details.
-
-## Troubleshooting
-
-### Common Issues
-
-1. **"Command not found" errors**: Ensure ast-grep is installed and in your PATH
-2. **No matches found**: Try adding `stopBy: end` to relational rules
-3. **Pattern not matching**: Use `dump_syntax_tree` to understand the AST structure
-4. **Permission errors**: Ensure the server has read access to target directories
-
-## Contributing
-
-This is an experimental project. Issues and pull requests are welcome!
-
-## Related Projects
-
-- [ast-grep](https://ast-grep.github.io/) - The core structural search tool
-- [Model Context Protocol](https://modelcontextprotocol.io/) - The protocol this server implements
-- [FastMCP](https://github.com/pydantic/fastmcp) - The Python MCP framework used
-- [Codemod MCP](https://docs.codemod.com/model-context-protocol) - Gives AI assistants tools like tree-sitter AST and node types, ast-grep instructions (YAML and JS ast-grep), and Codemod CLI commands to easily build, publish, and run ast-grep based codemods.
-
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/ast-grep-ast-grep-mcp-badge.png)](https://mseep.ai/app/ast-grep-ast-grep-mcp)
+For rule design, follow ast-grep's [AI prompting workflow](https://astgrep.com/advanced/prompting.html), [rule testing guidance](https://astgrep.com/guide/test-rule.html), and [rewriting guide](https://astgrep.com/guide/rewrite-code.html). Rewriting is intentionally outside this MCP server.

--- a/main.py
+++ b/main.py
@@ -1,417 +1,898 @@
+from __future__ import annotations
+
 import argparse
 import json
 import os
-import signal
+import shutil
 import subprocess
-import sys
-from typing import Any, List, Literal, Optional
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Annotated, Any, Final, Literal, TypedDict
 
-import yaml
+import yaml as yaml_parser
 from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from pydantic import Field
 
+DEFAULT_MAX_RESULTS: Final = 50
+HARD_MAX_RESULTS: Final = 500
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final = 30.0
+FALLBACK_SERVER_VERSION: Final = "0.2.0"
 
-# Multi-session stability: Handle SIGINT gracefully
-# Claude Code sends SIGINT to existing MCP processes when new sessions start
-# We ignore SIGINT to maintain stability for the original session
-def _setup_signal_handlers():
-    """Setup signal handlers for multi-session stability."""
-
-    def sigint_handler(signum, frame):
-        # Log but don't exit - let the MCP server continue serving
-        print("Received SIGINT - ignoring for multi-session stability", file=sys.stderr)
-
-    def sigterm_handler(signum, frame):
-        # SIGTERM is a polite termination request - we should honor it
-        print("Received SIGTERM - shutting down gracefully", file=sys.stderr)
-        sys.exit(0)
-
-    # Windows doesn't have SIGINT the same way, but we handle it anyway
-    if hasattr(signal, "SIGINT"):
-        signal.signal(signal.SIGINT, sigint_handler)
-    if hasattr(signal, "SIGTERM"):
-        signal.signal(signal.SIGTERM, sigterm_handler)
-
-
-_setup_signal_handlers()
-
-# Global variables (will be set by parse_args_and_get_config)
-CONFIG_PATH = None
-TRANSPORT_TYPE = "stdio"
-SERVER_PORT = 8000
-
-
-def parse_args_and_get_config():
-    """Parse command-line arguments and determine config path and transport."""
-    global CONFIG_PATH, TRANSPORT_TYPE, SERVER_PORT
-
-    # Determine how the script was invoked
-    prog = None
-    if sys.argv[0].endswith("main.py"):
-        # Direct execution: python main.py
-        prog = "python main.py"
-
-    # Parse command-line arguments
-    parser = argparse.ArgumentParser(
-        prog=prog,
-        description="ast-grep MCP Server - Provides structural code search capabilities via Model Context Protocol",
-        epilog="""
-environment variables:
-  AST_GREP_CONFIG    Path to sgconfig.yaml file (overridden by --config flag)
-
-For more information, see: https://github.com/ast-grep/ast-grep-mcp
-        """,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument(
-        "--config",
-        type=str,
-        metavar="PATH",
-        help="Path to sgconfig.yaml file for customizing ast-grep behavior (language mappings, rule directories, etc.)",
-    )
-    parser.add_argument(
-        "--transport", type=str, choices=["stdio", "sse"], default="stdio", help="Transport type for MCP server (default: stdio)"
-    )
-    parser.add_argument("--port", type=int, default=3101, help="Port for SSE transport (default: 3101)")
-    args = parser.parse_args()
-
-    # Set transport type and port
-    TRANSPORT_TYPE = args.transport
-    SERVER_PORT = args.port
-
-    # Determine config path with precedence: --config flag > AST_GREP_CONFIG env > None
-    if args.config:
-        if not os.path.exists(args.config):
-            print(f"Error: Config file '{args.config}' does not exist")
-            sys.exit(1)
-        CONFIG_PATH = args.config
-    elif os.environ.get("AST_GREP_CONFIG"):
-        env_config = os.environ.get("AST_GREP_CONFIG")
-        if env_config and not os.path.exists(env_config):
-            print(f"Error: Config file '{env_config}' specified in AST_GREP_CONFIG does not exist")
-            sys.exit(1)
-        CONFIG_PATH = env_config
-
-
-# Initialize FastMCP server
-mcp = FastMCP("ast-grep")
+BUILTIN_LANGUAGES: Final = (
+    "bash",
+    "c",
+    "cpp",
+    "csharp",
+    "css",
+    "elixir",
+    "go",
+    "haskell",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "jsx",
+    "kotlin",
+    "lua",
+    "nix",
+    "php",
+    "python",
+    "ruby",
+    "rust",
+    "scala",
+    "solidity",
+    "swift",
+    "tsx",
+    "typescript",
+    "yaml",
+)
 
 DumpFormat = Literal["pattern", "cst", "ast"]
+OutputFormat = Literal["text", "json"]
+Transport = Literal["stdio", "sse", "streamable-http"]
+CompletedTextProcess = subprocess.CompletedProcess[str]
+ProcessRunner = Callable[..., CompletedTextProcess]
 
 
-def register_mcp_tools() -> None:
-    @mcp.tool()
-    def dump_syntax_tree(
-        code: str = Field(description="The code you need"),
-        language: str = Field(description=f"The language of the code. Supported: {', '.join(get_supported_languages())}"),
-        format: DumpFormat = Field(description="Code dump format. Available values: pattern, ast, cst", default="cst"),
-    ) -> str:
-        """
-        Dump code's syntax structure or dump a query's pattern structure.
-        This is useful to discover correct syntax kind and syntax tree structure. Call it when debugging a rule.
-        The tool requires three arguments: code, language and format. The first two are self-explanatory.
-        `format` is the output format of the syntax tree.
-        use `format=cst` to inspect the code's concrete syntax tree structure, useful to debug target code.
-        use `format=pattern` to inspect how ast-grep interprets a pattern, useful to debug pattern rule.
-
-        Internally calls: ast-grep run --pattern <code> --lang <language> --debug-query=<format>
-        """
-        result = run_ast_grep("run", ["--pattern", code, "--lang", language, f"--debug-query={format}"])
-        return result.stderr.strip()  # type: ignore[no-any-return]
-
-    @mcp.tool()
-    def test_match_code_rule(
-        code: str = Field(description="The code to test against the rule"),
-        yaml: str = Field(description="The ast-grep YAML rule to search. It must have id, language, rule fields."),
-    ) -> List[dict[str, Any]]:
-        """
-        Test a code against an ast-grep YAML rule.
-        This is useful to test a rule before using it in a project.
-
-        Internally calls: ast-grep scan --inline-rules <yaml> --json --stdin
-        """
-        result = run_ast_grep("scan", ["--inline-rules", yaml, "--json", "--stdin"], input_text=code)
-        matches = json.loads(result.stdout.strip())
-        if not matches:
-            raise ValueError("No matches found for the given code and rule. Try adding `stopBy: end` to your inside/has rule.")
-        return matches  # type: ignore[no-any-return]
-
-    @mcp.tool()
-    def find_code(
-        project_folder: str = Field(description="The absolute path to the project folder. It must be absolute path."),
-        pattern: str = Field(description="The ast-grep pattern to search for. Note, the pattern must have valid AST structure."),
-        language: str = Field(
-            description=f"The language of the code. Supported: {', '.join(get_supported_languages())}. "
-            "If not specified, will be auto-detected based on file extensions.",
-            default="",
-        ),
-        max_results: int = Field(default=0, description="Maximum results to return"),
-        output_format: str = Field(default="text", description="'text' or 'json'"),
-    ) -> str | List[dict[str, Any]]:
-        """
-        Find code in a project folder that matches the given ast-grep pattern.
-        Pattern is good for simple and single-AST node result.
-        For more complex usage, please use YAML by `find_code_by_rule`.
-
-        Internally calls: ast-grep run --pattern <pattern> [--json] <project_folder>
-
-        Output formats:
-        - text (default): Compact text format with file:line-range headers and complete match text
-          Example:
-            Found 2 matches:
-
-            path/to/file.py:10-15
-            def example_function():
-                # function body
-                return result
-
-            path/to/file.py:20-22
-            def another_function():
-                pass
-
-        - json: Full match objects with metadata including ranges, meta-variables, etc.
-
-        The max_results parameter limits the number of complete matches returned (not individual lines).
-        When limited, the header shows "Found X matches (showing first Y of Z)".
-
-        Example usage:
-          find_code(pattern="class $NAME", max_results=20)  # Returns text format
-          find_code(pattern="class $NAME", output_format="json")  # Returns JSON with metadata
-        """
-        if output_format not in ["text", "json"]:
-            raise ValueError(f"Invalid output_format: {output_format}. Must be 'text' or 'json'.")
-
-        args = ["--pattern", pattern]
-        if language:
-            args.extend(["--lang", language])
-
-        # Always get JSON internally for accurate match limiting
-        result = run_ast_grep("run", args + ["--json=stream", project_folder])
-        matches, total_matches = parse_matches(result.stdout, max_results)
-
-        if output_format == "text":
-            if not matches:
-                return "No matches found"
-            text_output = format_matches_as_text(matches)
-            header = f"Found {len(matches)} matches"
-            if max_results and total_matches > max_results:
-                header += f" (showing first {max_results} of {total_matches})"
-            return header + ":\n\n" + text_output
-        return matches  # type: ignore[no-any-return]
-
-    @mcp.tool()
-    def find_code_by_rule(
-        project_folder: str = Field(description="The absolute path to the project folder. It must be absolute path."),
-        yaml: str = Field(description="The ast-grep YAML rule to search. It must have id, language, rule fields."),
-        max_results: int = Field(default=0, description="Maximum results to return"),
-        output_format: str = Field(default="text", description="'text' or 'json'"),
-    ) -> str | List[dict[str, Any]]:
-        """
-        Find code using ast-grep's YAML rule in a project folder.
-        YAML rule is more powerful than simple pattern and can perform complex search like find AST inside/having another AST.
-        It is a more advanced search tool than the simple `find_code`.
-
-        Tip: When using relational rules (inside/has), add `stopBy: end` to ensure complete traversal.
-
-        Internally calls: ast-grep scan --inline-rules <yaml> [--json] <project_folder>
-
-        Output formats:
-        - text (default): Compact text format with file:line-range headers and complete match text
-          Example:
-            Found 2 matches:
-
-            src/models.py:45-52
-            class UserModel:
-                def __init__(self):
-                    self.id = None
-                    self.name = None
-
-            src/views.py:12
-            class SimpleView: pass
-
-        - json: Full match objects with metadata including ranges, meta-variables, etc.
-
-        The max_results parameter limits the number of complete matches returned (not individual lines).
-        When limited, the header shows "Found X matches (showing first Y of Z)".
-
-        Example usage:
-          find_code_by_rule(yaml="id: x\\nlanguage: python\\nrule: {pattern: 'class $NAME'}", max_results=20)
-          find_code_by_rule(yaml="...", output_format="json")  # For full metadata
-        """
-        if output_format not in ["text", "json"]:
-            raise ValueError(f"Invalid output_format: {output_format}. Must be 'text' or 'json'.")
-
-        args = ["--inline-rules", yaml]
-
-        # Always get JSON internally for accurate match limiting
-        result = run_ast_grep("scan", args + ["--json=stream", project_folder])
-        matches, total_matches = parse_matches(result.stdout, max_results)
-
-        if output_format == "text":
-            if not matches:
-                return "No matches found"
-            text_output = format_matches_as_text(matches)
-            header = f"Found {len(matches)} matches"
-            if max_results and total_matches > max_results:
-                header += f" (showing first {max_results} of {total_matches})"
-            return header + ":\n\n" + text_output
-        return matches  # type: ignore[no-any-return]
+class SearchResults(TypedDict):
+    matches: list[dict[str, Any]]
+    returned: int
+    truncated: bool
+    limit: int
 
 
-def parse_matches(stdout: str, max_results: int = 0) -> tuple[list[dict], int]:
-    """Parse JSONL (--json=stream) output with optional early exit.
-
-    Returns (matches, total_count). Only parses JSON for kept matches;
-    remaining lines are counted but not deserialized. Non-JSON lines
-    (e.g. ast-grep warnings) are skipped.
-    """
-    matches: list[dict] = []
-    total_lines = 0
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line or not line.startswith("{"):
-            continue
-        total_lines += 1
-        if not max_results or len(matches) < max_results:
-            matches.append(json.loads(line))
-    return matches, total_lines
+class ServerInfo(TypedDict):
+    fork_version: str
+    ast_grep_executable: str
+    ast_grep_version: str
+    config_path: str | None
+    allowed_roots: list[str]
+    command_timeout_seconds: float
+    default_max_results: int
+    max_results_cap: int
+    forbid_regex_rules: bool
 
 
-def format_matches_as_text(matches: List[dict]) -> str:
-    """Convert JSON matches to LLM-friendly text format.
-
-    Format: file:start-end followed by the complete match text.
-    Matches are separated by blank lines for clarity.
-    """
-    if not matches:
-        return ""
-
-    output_blocks = []
-    for m in matches:
-        file_path = m.get("file", "")
-        start_line = m.get("range", {}).get("start", {}).get("line", 0) + 1
-        end_line = m.get("range", {}).get("end", {}).get("line", 0) + 1
-        match_text = m.get("text", "").rstrip()
-
-        # Format: filepath:start-end (or just :line for single-line matches)
-        if start_line == end_line:
-            header = f"{file_path}:{start_line}"
-        else:
-            header = f"{file_path}:{start_line}-{end_line}"
-
-        output_blocks.append(f"{header}\n{match_text}")
-
-    return "\n\n".join(output_blocks)
+@dataclass(frozen=True)
+class ResolvedExecutable:
+    path: Path
+    command_prefix: tuple[str, ...]
 
 
-def get_supported_languages() -> List[str]:
-    """Get all supported languages as a field description string."""
-    languages = [  # https://ast-grep.github.io/reference/languages.html
-        "bash",
-        "c",
-        "cpp",
-        "csharp",
-        "css",
-        "elixir",
-        "go",
-        "haskell",
-        "html",
-        "java",
-        "javascript",
-        "json",
-        "jsx",
-        "kotlin",
-        "lua",
-        "nix",
-        "php",
-        "python",
-        "ruby",
-        "rust",
-        "scala",
-        "solidity",
-        "swift",
-        "tsx",
-        "typescript",
-        "yaml",
-    ]
-
-    # Check for custom languages in config file
-    # https://ast-grep.github.io/advanced/custom-language.html#register-language-in-sgconfig-yml
-    if CONFIG_PATH and os.path.exists(CONFIG_PATH):
-        try:
-            with open(CONFIG_PATH, "r") as f:
-                config = yaml.safe_load(f)
-                if config and "customLanguages" in config:
-                    custom_langs = list(config["customLanguages"].keys())
-                    languages += custom_langs
-        except Exception:
-            pass
-
-    return sorted(set(languages))
+@dataclass(frozen=True)
+class ServerRuntime:
+    working_directory: Path
+    executable: ResolvedExecutable
+    ast_grep_version: str
+    config_path: Path | None
+    allowed_roots: tuple[Path, ...]
+    command_timeout_seconds: float
+    default_max_results: int
+    max_results_cap: int
+    forbid_regex_rules: bool
 
 
-def run_command(args: List[str], input_text: Optional[str] = None) -> subprocess.CompletedProcess:
+READ_ONLY_ANNOTATIONS: Final = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+
+def _server_version() -> str:
     try:
-        # On Windows, if ast-grep is installed via npm, it's a batch file
-        # that requires shell=True to execute properly
-        use_shell = sys.platform == "win32" and args[0] == "ast-grep"
-        need_check = len(args) < 2 or args[1] != "run"
+        return version("sg-mcp")
+    except PackageNotFoundError:
+        return FALLBACK_SERVER_VERSION
 
-        result = subprocess.run(
-            args,
+
+def _is_within(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def _resolve_existing_path(raw_path: str, *, base: Path, kind: Literal["file", "directory"]) -> Path:
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = base / candidate
+    try:
+        resolved = candidate.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise ValueError(f"{kind.capitalize()} does not exist: {raw_path}") from error
+    if kind == "directory" and not resolved.is_dir():
+        raise ValueError(f"Expected a directory: {raw_path}")
+    if kind == "file" and not resolved.is_file():
+        raise ValueError(f"Expected a file: {raw_path}")
+    return resolved
+
+
+def resolve_allowed_roots(raw_roots: Sequence[str], *, working_directory: Path) -> tuple[Path, ...]:
+    roots = raw_roots or [str(working_directory)]
+    resolved_roots: list[Path] = []
+    for raw_root in roots:
+        root = _resolve_existing_path(raw_root, base=working_directory, kind="directory")
+        if root not in resolved_roots:
+            resolved_roots.append(root)
+    return tuple(resolved_roots)
+
+
+def _require_allowed(path: Path, allowed_roots: Sequence[Path], *, label: str) -> None:
+    if not any(_is_within(path, root) for root in allowed_roots):
+        allowed = ", ".join(str(root) for root in allowed_roots)
+        raise ValueError(f"{label} resolves outside the allowed roots ({allowed}): {path}")
+
+
+def _read_json_file(path: Path) -> Mapping[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, Mapping) else None
+
+
+def _npm_package_bin(package_directory: Path) -> Path | None:
+    manifest_path = package_directory / "package.json"
+    manifest = _read_json_file(manifest_path)
+    if manifest is None or manifest.get("name") != "@ast-grep/cli":
+        return None
+
+    bin_value = manifest.get("bin")
+    if isinstance(bin_value, str):
+        relative_bin = bin_value
+    elif isinstance(bin_value, Mapping) and isinstance(bin_value.get("ast-grep"), str):
+        relative_bin = bin_value["ast-grep"]
+    else:
+        return None
+
+    try:
+        target = (package_directory / relative_bin).resolve(strict=True)
+    except FileNotFoundError:
+        return None
+    if not target.is_file() or not _is_within(target, package_directory.resolve()):
+        return None
+    return target
+
+
+def _find_npm_ast_grep_bin(shim_path: Path, resolved_path: Path) -> Path | None:
+    package_candidates: list[Path] = []
+    if shim_path.parent.name == ".bin":
+        package_candidates.append(shim_path.parent.parent / "@ast-grep" / "cli")
+    package_candidates.append(shim_path.parent / "node_modules" / "@ast-grep" / "cli")
+
+    for parent in resolved_path.parents:
+        if len(package_candidates) >= 12:
+            break
+        package_candidates.append(parent)
+
+    seen: set[Path] = set()
+    for candidate in package_candidates:
+        normalized = candidate.absolute()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        target = _npm_package_bin(candidate)
+        if target is not None:
+            return target
+    return None
+
+
+def resolve_ast_grep_executable(raw_executable: str, *, working_directory: Path) -> ResolvedExecutable:
+    raw_path = Path(raw_executable).expanduser()
+    has_path_separator = os.sep in raw_executable or (os.altsep is not None and os.altsep in raw_executable)
+    if raw_path.is_absolute() or has_path_separator:
+        shim_path = raw_path if raw_path.is_absolute() else working_directory / raw_path
+        if not shim_path.exists():
+            raise ValueError(f"ast-grep executable does not exist: {raw_executable}")
+    else:
+        discovered = shutil.which(raw_executable)
+        if discovered is None:
+            raise ValueError(f"ast-grep executable was not found: {raw_executable}")
+        shim_path = Path(discovered)
+
+    try:
+        resolved_path = shim_path.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise ValueError(f"ast-grep executable does not exist: {raw_executable}") from error
+    if not resolved_path.is_file():
+        raise ValueError(f"ast-grep executable is not a file: {raw_executable}")
+
+    npm_bin = _find_npm_ast_grep_bin(shim_path.absolute(), resolved_path)
+    if npm_bin is not None:
+        node = shutil.which("node")
+        if node is None:
+            raise ValueError("The @ast-grep/cli launcher requires Node.js, but node was not found")
+        node_path = Path(node).resolve(strict=True)
+        return ResolvedExecutable(path=npm_bin, command_prefix=(str(node_path), str(npm_bin)))
+
+    if resolved_path.suffix.lower() in {".bat", ".cmd"}:
+        raise ValueError(
+            "Batch-file ast-grep launchers are not executed through a shell; install @ast-grep/cli or pass its resolved executable"
+        )
+    if os.name != "nt" and not os.access(resolved_path, os.X_OK):
+        raise ValueError(f"ast-grep executable is not executable: {resolved_path}")
+    return ResolvedExecutable(path=resolved_path, command_prefix=(str(resolved_path),))
+
+
+def _bounded_error_text(value: str | None, *, limit: int = 4000) -> str:
+    text = (value or "").strip()
+    if not text:
+        return "(no error output)"
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "…"
+
+
+def run_process(
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+    input_text: str | None = None,
+    working_directory: Path | None = None,
+    allowed_exit_codes: frozenset[int] = frozenset({0}),
+    runner: ProcessRunner = subprocess.run,
+) -> CompletedTextProcess:
+    try:
+        result = runner(
+            list(command),
             capture_output=True,
             input=input_text,
             text=True,
-            check=need_check,  # Don't raise on non-zero exit code, handle it manually
-            shell=use_shell,
+            timeout=timeout_seconds,
+            cwd=str(working_directory) if working_directory is not None else None,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"Command timed out after {timeout_seconds:g} seconds") from error
+    except FileNotFoundError as error:
+        raise RuntimeError(f"Command executable was not found: {command[0]}") from error
+
+    if result.returncode not in allowed_exit_codes:
+        detail = _bounded_error_text(result.stderr)
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {detail}")
+    return result
+
+
+def _read_ast_grep_version(
+    executable: ResolvedExecutable,
+    *,
+    timeout_seconds: float,
+    runner: ProcessRunner = subprocess.run,
+) -> str:
+    result = run_process(
+        [*executable.command_prefix, "--version"],
+        timeout_seconds=timeout_seconds,
+        runner=runner,
+    )
+    parts = result.stdout.strip().split()
+    if len(parts) < 2 or parts[0] != "ast-grep":
+        raise ValueError(f"Configured executable is not ast-grep: {_bounded_error_text(result.stdout)}")
+    return parts[1]
+
+
+def build_runtime(
+    *,
+    working_directory: Path,
+    ast_grep_executable: str = "ast-grep",
+    config_path: str | None = None,
+    allowed_roots: Sequence[str] = (),
+    command_timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    default_max_results: int = DEFAULT_MAX_RESULTS,
+    max_results_cap: int = HARD_MAX_RESULTS,
+    forbid_regex_rules: bool = False,
+    runner: ProcessRunner = subprocess.run,
+) -> ServerRuntime:
+    resolved_working_directory = working_directory.resolve(strict=True)
+    if not resolved_working_directory.is_dir():
+        raise ValueError(f"Working directory is not a directory: {working_directory}")
+    if command_timeout_seconds <= 0:
+        raise ValueError("Command timeout must be greater than zero")
+    if not 1 <= max_results_cap <= HARD_MAX_RESULTS:
+        raise ValueError(f"Result cap must be between 1 and {HARD_MAX_RESULTS}")
+    if not 1 <= default_max_results <= max_results_cap:
+        raise ValueError("Default result limit must be positive and no greater than the configured cap")
+
+    resolved_roots = resolve_allowed_roots(allowed_roots, working_directory=resolved_working_directory)
+    executable = resolve_ast_grep_executable(ast_grep_executable, working_directory=resolved_working_directory)
+    resolved_config: Path | None = None
+    if config_path is not None:
+        resolved_config = _resolve_existing_path(config_path, base=resolved_working_directory, kind="file")
+        _require_allowed(resolved_config, resolved_roots, label="Config path")
+
+    return ServerRuntime(
+        working_directory=resolved_working_directory,
+        executable=executable,
+        ast_grep_version=_read_ast_grep_version(
+            executable,
+            timeout_seconds=command_timeout_seconds,
+            runner=runner,
+        ),
+        config_path=resolved_config,
+        allowed_roots=resolved_roots,
+        command_timeout_seconds=command_timeout_seconds,
+        default_max_results=default_max_results,
+        max_results_cap=max_results_cap,
+        forbid_regex_rules=forbid_regex_rules,
+    )
+
+
+def get_supported_languages(config_path: Path | None = None) -> list[str]:
+    languages = set(BUILTIN_LANGUAGES)
+    if config_path is None:
+        return sorted(languages)
+
+    try:
+        config = yaml_parser.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml_parser.YAMLError) as error:
+        raise ValueError(f"Unable to read ast-grep config: {config_path}") from error
+    if config is None:
+        return sorted(languages)
+    if not isinstance(config, Mapping):
+        raise ValueError(f"ast-grep config must contain a YAML mapping: {config_path}")
+    custom_languages = config.get("customLanguages")
+    if custom_languages is not None:
+        if not isinstance(custom_languages, Mapping):
+            raise ValueError("customLanguages must be a mapping")
+        languages.update(str(name) for name in custom_languages)
+    return sorted(languages)
+
+
+def _contains_mapping_key(value: Any, forbidden_key: str) -> bool:
+    if isinstance(value, Mapping):
+        return any(key == forbidden_key or _contains_mapping_key(item, forbidden_key) for key, item in value.items())
+    if isinstance(value, list):
+        return any(_contains_mapping_key(item, forbidden_key) for item in value)
+    return False
+
+
+def validate_rule_yaml(rule_yaml: str, *, forbid_regex_rules: bool) -> None:
+    try:
+        documents = list(yaml_parser.safe_load_all(rule_yaml))
+    except yaml_parser.YAMLError as error:
+        raise ValueError(f"Invalid ast-grep rule YAML: {error}") from error
+    if not documents or all(document is None for document in documents):
+        raise ValueError("ast-grep rule YAML must contain at least one rule")
+
+    for document in documents:
+        if not isinstance(document, Mapping):
+            raise ValueError("Each ast-grep inline rule must be a YAML mapping")
+        missing = [key for key in ("id", "language", "rule") if key not in document]
+        if missing:
+            raise ValueError(f"ast-grep rule is missing required fields: {', '.join(missing)}")
+        if not isinstance(document["rule"], Mapping):
+            raise ValueError("ast-grep rule field must be a mapping")
+        if forbid_regex_rules and _contains_mapping_key(document, "regex"):
+            raise ValueError("Regex ast-grep rules are disabled by server policy")
+
+
+def parse_stream_matches(stdout: str) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(stdout.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"ast-grep emitted invalid JSON on line {line_number}") from error
+        if not isinstance(value, dict):
+            raise RuntimeError(f"ast-grep emitted a non-object JSON match on line {line_number}")
+        matches.append(value)
+    return matches
+
+
+def format_matches_as_text(matches: Sequence[Mapping[str, Any]]) -> str:
+    output_blocks: list[str] = []
+    for match in matches:
+        file_path = str(match.get("file", ""))
+        range_value = match.get("range")
+        range_mapping = range_value if isinstance(range_value, Mapping) else {}
+        start_value = range_mapping.get("start")
+        end_value = range_mapping.get("end")
+        start_mapping = start_value if isinstance(start_value, Mapping) else {}
+        end_mapping = end_value if isinstance(end_value, Mapping) else {}
+        start_line = int(start_mapping.get("line", 0)) + 1
+        end_line = int(end_mapping.get("line", start_line - 1)) + 1
+        match_text = str(match.get("text", "")).rstrip()
+        header = f"{file_path}:{start_line}" if start_line == end_line else f"{file_path}:{start_line}-{end_line}"
+        output_blocks.append(f"{header}\n{match_text}")
+    return "\n\n".join(output_blocks)
+
+
+def format_search_results(results: SearchResults) -> str:
+    if results["returned"] == 0:
+        return "No matches found"
+    noun = "match" if results["returned"] == 1 else "matches"
+    header = f"Found {results['returned']} {noun}"
+    if results["truncated"]:
+        header += f" (limit {results['limit']}; additional matches exist)"
+    return f"{header}:\n\n{format_matches_as_text(results['matches'])}"
+
+
+def search_tool_result(results: SearchResults, output_format: OutputFormat) -> CallToolResult:
+    if output_format == "json":
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(results, separators=(",", ":")))],
+            structuredContent=dict(results),
+        )
+    return CallToolResult(content=[TextContent(type="text", text=format_search_results(results))])
+
+
+class AstGrepService:
+    def __init__(self, runtime: ServerRuntime, *, runner: ProcessRunner = subprocess.run) -> None:
+        self.runtime = runtime
+        self.runner = runner
+
+    def _run(
+        self,
+        subcommand: str,
+        arguments: Sequence[str],
+        *,
+        input_text: str | None = None,
+        working_directory: Path | None = None,
+        allow_no_matches: bool = False,
+    ) -> CompletedTextProcess:
+        command = [*self.runtime.executable.command_prefix, subcommand]
+        if self.runtime.config_path is not None:
+            command.extend(["--config", str(self.runtime.config_path)])
+        command.extend(arguments)
+        result = run_process(
+            command,
+            timeout_seconds=self.runtime.command_timeout_seconds,
+            input_text=input_text,
+            working_directory=working_directory or self.runtime.working_directory,
+            allowed_exit_codes=frozenset({0, 1}) if allow_no_matches else frozenset({0}),
+            runner=self.runner,
+        )
+        if result.returncode == 1 and result.stderr.strip() and not result.stdout.strip():
+            raise RuntimeError(f"ast-grep search failed: {_bounded_error_text(result.stderr)}")
+        return result
+
+    def _validate_language(self, language: str) -> None:
+        if not language:
+            raise ValueError("language is required")
+        if language not in get_supported_languages(self.runtime.config_path):
+            raise ValueError(f"Unsupported ast-grep language: {language}")
+
+    def _resolve_project(self, project_folder: str) -> Path:
+        project = _resolve_existing_path(
+            project_folder,
+            base=self.runtime.working_directory,
+            kind="directory",
+        )
+        _require_allowed(project, self.runtime.allowed_roots, label="Project folder")
+        return project
+
+    def _resolve_paths(self, project: Path, raw_paths: Sequence[str] | None) -> list[Path]:
+        paths = list(raw_paths or ["."])
+        if not paths:
+            raise ValueError("paths must contain at least one relative path")
+        resolved_paths: list[Path] = []
+        for raw_path in paths:
+            if not raw_path:
+                raise ValueError("paths cannot contain empty values")
+            candidate = Path(raw_path)
+            if candidate.is_absolute():
+                raise ValueError(f"Search paths must be relative to project_folder: {raw_path}")
+            try:
+                resolved = (project / candidate).resolve(strict=True)
+            except FileNotFoundError as error:
+                raise ValueError(f"Search path does not exist: {raw_path}") from error
+            if not _is_within(resolved, project):
+                raise ValueError(f"Search path resolves outside project_folder: {raw_path}")
+            _require_allowed(resolved, self.runtime.allowed_roots, label="Search path")
+            if resolved not in resolved_paths:
+                resolved_paths.append(resolved)
+        return resolved_paths
+
+    @staticmethod
+    def _glob_arguments(include_globs: Sequence[str] | None, exclude_globs: Sequence[str] | None) -> list[str]:
+        arguments: list[str] = []
+        for glob in include_globs or ():
+            if not glob or "\0" in glob or glob.startswith("!"):
+                raise ValueError(f"Invalid include glob: {glob!r}")
+            arguments.extend(["--globs", glob])
+        for glob in exclude_globs or ():
+            if not glob or "\0" in glob or glob.startswith("!"):
+                raise ValueError(f"Invalid exclude glob: {glob!r}")
+            arguments.extend(["--globs", f"!{glob}"])
+        return arguments
+
+    def _normalize_match_path(self, match: dict[str, Any], project: Path) -> dict[str, Any]:
+        raw_file = match.get("file")
+        if not isinstance(raw_file, str) or not raw_file:
+            return match
+        file_path = Path(raw_file)
+        if not file_path.is_absolute():
+            file_path = project / file_path
+        resolved_file = file_path.resolve(strict=True)
+        if not _is_within(resolved_file, project):
+            raise RuntimeError(f"ast-grep returned a match outside project_folder: {raw_file}")
+        normalized = dict(match)
+        normalized["file"] = resolved_file.relative_to(project).as_posix()
+        return normalized
+
+    def _result_limit(self, requested: int | None) -> int:
+        limit = self.runtime.default_max_results if requested is None else requested
+        if not 1 <= limit <= self.runtime.max_results_cap:
+            raise ValueError(f"max_results must be between 1 and {self.runtime.max_results_cap}")
+        return limit
+
+    def _search(
+        self,
+        *,
+        project_folder: str,
+        rule_yaml: str,
+        paths: Sequence[str] | None,
+        include_globs: Sequence[str] | None,
+        exclude_globs: Sequence[str] | None,
+        max_results: int | None,
+    ) -> SearchResults:
+        validate_rule_yaml(rule_yaml, forbid_regex_rules=self.runtime.forbid_regex_rules)
+        project = self._resolve_project(project_folder)
+        search_paths = self._resolve_paths(project, paths)
+        limit = self._result_limit(max_results)
+        arguments = [
+            "--inline-rules",
+            rule_yaml,
+            "--json=stream",
+            "--max-results",
+            str(limit + 1),
+            *self._glob_arguments(include_globs, exclude_globs),
+            *(str(path) for path in search_paths),
+        ]
+        result = self._run(
+            "scan",
+            arguments,
+            working_directory=project,
+            allow_no_matches=True,
+        )
+        parsed_matches = parse_stream_matches(result.stdout)
+        truncated = len(parsed_matches) > limit
+        matches = [self._normalize_match_path(match, project) for match in parsed_matches[:limit]]
+        return {
+            "matches": matches,
+            "returned": len(matches),
+            "truncated": truncated,
+            "limit": limit,
+        }
+
+    def dump_syntax_tree(self, *, code: str, language: str, format: DumpFormat) -> str:
+        self._validate_language(language)
+        result = self._run(
+            "run",
+            ["--pattern", code, "--lang", language, f"--debug-query={format}"],
+            allow_no_matches=True,
+        )
+        return result.stderr.strip()
+
+    def test_match_code_rule(self, *, code: str, rule_yaml: str) -> list[dict[str, Any]]:
+        validate_rule_yaml(rule_yaml, forbid_regex_rules=self.runtime.forbid_regex_rules)
+        result = self._run(
+            "scan",
+            [
+                "--inline-rules",
+                rule_yaml,
+                "--json=stream",
+                "--max-results",
+                str(self.runtime.max_results_cap),
+                "--stdin",
+            ],
+            input_text=code,
+            allow_no_matches=True,
+        )
+        return parse_stream_matches(result.stdout)
+
+    def find_code(
+        self,
+        *,
+        project_folder: str,
+        pattern: str,
+        language: str,
+        paths: Sequence[str] | None,
+        include_globs: Sequence[str] | None,
+        exclude_globs: Sequence[str] | None,
+        max_results: int | None,
+    ) -> SearchResults:
+        self._validate_language(language)
+        rule_yaml = yaml_parser.safe_dump(
+            {
+                "id": "mcp-pattern-search",
+                "language": language,
+                "rule": {"pattern": pattern},
+            },
+            sort_keys=False,
+        )
+        return self._search(
+            project_folder=project_folder,
+            rule_yaml=rule_yaml,
+            paths=paths,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+            max_results=max_results,
         )
 
-        # ast-grep returns exit code 1 when no matches are found, but this is not an error.
-        # Only raise an exception for actual errors (exit code != 0 and != 1)
-        # or when exit code is 1 but stdout doesn't look like valid JSON output
-        if result.returncode != 0:
-            if result.returncode == 1:
-                stdout_stripped = result.stdout.strip()
+    def find_code_by_rule(
+        self,
+        *,
+        project_folder: str,
+        rule_yaml: str,
+        paths: Sequence[str] | None,
+        include_globs: Sequence[str] | None,
+        exclude_globs: Sequence[str] | None,
+        max_results: int | None,
+    ) -> SearchResults:
+        return self._search(
+            project_folder=project_folder,
+            rule_yaml=rule_yaml,
+            paths=paths,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+            max_results=max_results,
+        )
 
-                # Valid "no matches" cases: empty JSON array or valid JSON with matches
-                if stdout_stripped in ("", "[]") or stdout_stripped.startswith("[") or stdout_stripped.startswith("{"):
-                    return result
-
-                # If --json flag is not present, empty stdout is also valid "no matches"
-                if "--json" not in args and stdout_stripped == "":
-                    return result
-
-            # For all other non-zero exit codes, raise an error
-            stderr_msg = result.stderr.strip() if result.stderr else "(no error output)"
-            error_msg = f"Command {args} failed with exit code {result.returncode}: {stderr_msg}"
-            raise RuntimeError(error_msg)
-
-        return result
-    except subprocess.CalledProcessError as e:
-        stderr_msg = e.stderr.strip() if e.stderr else "(no error output)"
-        error_msg = f"Command {e.cmd} failed with exit code {e.returncode}: {stderr_msg}"
-        raise RuntimeError(error_msg) from e
-    except FileNotFoundError as e:
-        error_msg = f"Command '{args[0]}' not found. Please ensure {args[0]} is installed and in PATH."
-        raise RuntimeError(error_msg) from e
+    def get_server_info(self) -> ServerInfo:
+        return {
+            "fork_version": _server_version(),
+            "ast_grep_executable": str(self.runtime.executable.path),
+            "ast_grep_version": self.runtime.ast_grep_version,
+            "config_path": str(self.runtime.config_path) if self.runtime.config_path is not None else None,
+            "allowed_roots": [str(root) for root in self.runtime.allowed_roots],
+            "command_timeout_seconds": self.runtime.command_timeout_seconds,
+            "default_max_results": self.runtime.default_max_results,
+            "max_results_cap": self.runtime.max_results_cap,
+            "forbid_regex_rules": self.runtime.forbid_regex_rules,
+        }
 
 
-def run_ast_grep(command: str, args: List[str], input_text: Optional[str] = None) -> subprocess.CompletedProcess:
-    if CONFIG_PATH:
-        args = ["--config", CONFIG_PATH] + args
-    return run_command(["ast-grep", command] + args, input_text)
+_runtime: ServerRuntime | None = None
+
+
+def configure_runtime(runtime: ServerRuntime) -> None:
+    global _runtime
+    _runtime = runtime
+
+
+def current_service() -> AstGrepService:
+    if _runtime is None:
+        raise RuntimeError("ast-grep MCP runtime has not been configured")
+    return AstGrepService(_runtime)
+
+
+mcp = FastMCP(
+    "ast-grep",
+    instructions=(
+        "Read-only structural code inspection. Inspect syntax and probe rules before bounded project searches. "
+        "Use repository CLI workflows for exhaustive scans and rewrites."
+    ),
+)
+
+
+def register_mcp_tools(server: FastMCP) -> None:
+    @server.tool(annotations=READ_ONLY_ANNOTATIONS)
+    def dump_syntax_tree(
+        code: Annotated[str, Field(description="Code or pattern to inspect")],
+        language: Annotated[str, Field(description="Explicit ast-grep language")],
+        format: Annotated[
+            DumpFormat,
+            Field(description="Syntax dump format: pattern, ast, or cst"),
+        ] = "cst",
+    ) -> str:
+        """Inspect how ast-grep parses code or a query pattern."""
+        return current_service().dump_syntax_tree(code=code, language=language, format=format)
+
+    @server.tool(annotations=READ_ONLY_ANNOTATIONS)
+    def test_match_code_rule(
+        code: Annotated[str, Field(description="Code to test against the rule")],
+        yaml: Annotated[str, Field(description="ast-grep YAML with id, language, and rule fields")],
+    ) -> list[dict[str, Any]]:
+        """Probe an ast-grep YAML rule against a code snippet; a valid negative probe returns an empty list."""
+        return current_service().test_match_code_rule(code=code, rule_yaml=yaml)
+
+    @server.tool(annotations=READ_ONLY_ANNOTATIONS)
+    def find_code(
+        project_folder: Annotated[
+            str,
+            Field(description="Project directory, resolved and constrained to the server's allowed roots"),
+        ],
+        pattern: Annotated[str, Field(description="Valid ast-grep structural pattern")],
+        language: Annotated[str, Field(description="Required ast-grep language")],
+        paths: Annotated[
+            list[str] | None,
+            Field(description="Relative files or directories under project_folder; defaults to the project root"),
+        ] = None,
+        include_globs: Annotated[
+            list[str] | None,
+            Field(description="Optional gitignore-style include globs"),
+        ] = None,
+        exclude_globs: Annotated[
+            list[str] | None,
+            Field(description="Optional gitignore-style exclude globs, without a leading !"),
+        ] = None,
+        max_results: Annotated[
+            int | None,
+            Field(ge=1, le=HARD_MAX_RESULTS, description="Finite result limit; defaults to the server's configured limit"),
+        ] = None,
+        output_format: Annotated[
+            OutputFormat,
+            Field(description="Compact text or structured JSON result"),
+        ] = "text",
+    ) -> CallToolResult:
+        """Find bounded structural pattern matches inside an allowed project scope."""
+        results = current_service().find_code(
+            project_folder=project_folder,
+            pattern=pattern,
+            language=language,
+            paths=paths,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+            max_results=max_results,
+        )
+        return search_tool_result(results, output_format)
+
+    @server.tool(annotations=READ_ONLY_ANNOTATIONS)
+    def find_code_by_rule(
+        project_folder: Annotated[
+            str,
+            Field(description="Project directory, resolved and constrained to the server's allowed roots"),
+        ],
+        yaml: Annotated[str, Field(description="ast-grep YAML with id, language, and rule fields")],
+        paths: Annotated[
+            list[str] | None,
+            Field(description="Relative files or directories under project_folder; defaults to the project root"),
+        ] = None,
+        include_globs: Annotated[
+            list[str] | None,
+            Field(description="Optional gitignore-style include globs"),
+        ] = None,
+        exclude_globs: Annotated[
+            list[str] | None,
+            Field(description="Optional gitignore-style exclude globs, without a leading !"),
+        ] = None,
+        max_results: Annotated[
+            int | None,
+            Field(ge=1, le=HARD_MAX_RESULTS, description="Finite result limit; defaults to the server's configured limit"),
+        ] = None,
+        output_format: Annotated[
+            OutputFormat,
+            Field(description="Compact text or structured JSON result"),
+        ] = "text",
+    ) -> CallToolResult:
+        """Find bounded matches for one or more validated ast-grep YAML rules."""
+        results = current_service().find_code_by_rule(
+            project_folder=project_folder,
+            rule_yaml=yaml,
+            paths=paths,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+            max_results=max_results,
+        )
+        return search_tool_result(results, output_format)
+
+    @server.tool(annotations=READ_ONLY_ANNOTATIONS)
+    def get_server_info() -> ServerInfo:
+        """Report the fork, executable, containment, configuration, timeout, and result-limit contract."""
+        return current_service().get_server_info()
+
+
+register_mcp_tools(mcp)
+
+
+def _environment_bool(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean value")
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bounded, read-only ast-grep MCP server",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("AST_GREP_CONFIG"),
+        metavar="PATH",
+        help="Path to sgconfig.yml; it must resolve inside an allowed root",
+    )
+    parser.add_argument(
+        "--ast-grep",
+        default=os.environ.get("AST_GREP_EXECUTABLE", "ast-grep"),
+        metavar="PATH",
+        help="ast-grep executable or command name",
+    )
+    parser.add_argument(
+        "--allowed-root",
+        action="append",
+        default=None,
+        metavar="PATH",
+        help="Allowed project root; repeat for multiple roots (defaults to the process working directory)",
+    )
+    parser.add_argument(
+        "--command-timeout",
+        type=float,
+        default=float(os.environ.get("AST_GREP_COMMAND_TIMEOUT", DEFAULT_COMMAND_TIMEOUT_SECONDS)),
+        metavar="SECONDS",
+        help="Timeout for each ast-grep subprocess",
+    )
+    parser.add_argument(
+        "--default-max-results",
+        type=int,
+        default=int(os.environ.get("AST_GREP_DEFAULT_MAX_RESULTS", DEFAULT_MAX_RESULTS)),
+        metavar="COUNT",
+        help="Default finite search result limit",
+    )
+    parser.add_argument(
+        "--max-results-cap",
+        type=int,
+        default=int(os.environ.get("AST_GREP_MAX_RESULTS_CAP", HARD_MAX_RESULTS)),
+        metavar="COUNT",
+        help=f"Maximum allowed result limit (never above {HARD_MAX_RESULTS})",
+    )
+    parser.add_argument(
+        "--forbid-regex-rules",
+        action=argparse.BooleanOptionalAction,
+        default=_environment_bool("AST_GREP_FORBID_REGEX_RULES"),
+        help="Reject inline ast-grep YAML containing regex matcher keys",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+        help="MCP transport",
+    )
+    parser.add_argument("--port", type=int, default=3101, help="Port for HTTP transports")
+    return parser
 
 
 def run_mcp_server() -> None:
-    """
-    Run the MCP server.
-    This function is used to start the MCP server when this script is run directly.
-    """
-    parse_args_and_get_config()  # sets CONFIG_PATH, TRANSPORT_TYPE, and SERVER_PORT
-    register_mcp_tools()  # tools defined *after* CONFIG_PATH is known
-    if TRANSPORT_TYPE == "sse":
-        mcp.settings.port = SERVER_PORT
-    mcp.run(transport=TRANSPORT_TYPE) # type: ignore[arg-type]
+    parser = build_argument_parser()
+    args = parser.parse_args()
+    try:
+        runtime = build_runtime(
+            working_directory=Path.cwd(),
+            ast_grep_executable=args.ast_grep,
+            config_path=args.config,
+            allowed_roots=args.allowed_root or (),
+            command_timeout_seconds=args.command_timeout,
+            default_max_results=args.default_max_results,
+            max_results_cap=args.max_results_cap,
+            forbid_regex_rules=args.forbid_regex_rules,
+        )
+    except (RuntimeError, ValueError) as error:
+        parser.error(str(error))
+    configure_runtime(runtime)
+    mcp.settings.port = args.port
+    mcp.run(transport=args.transport)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -199,6 +199,16 @@ def _find_npm_ast_grep_bin(shim_path: Path, resolved_path: Path) -> Path | None:
     return None
 
 
+def _requires_node(executable: Path) -> bool:
+    if executable.suffix.lower() in {".cjs", ".js", ".mjs"}:
+        return True
+    try:
+        first_line = executable.open("rb").readline(256)
+    except OSError:
+        return False
+    return first_line.startswith(b"#!") and b"node" in first_line.lower()
+
+
 def resolve_ast_grep_executable(raw_executable: str, *, working_directory: Path) -> ResolvedExecutable:
     raw_path = Path(raw_executable).expanduser()
     has_path_separator = os.sep in raw_executable or (os.altsep is not None and os.altsep in raw_executable)
@@ -221,11 +231,15 @@ def resolve_ast_grep_executable(raw_executable: str, *, working_directory: Path)
 
     npm_bin = _find_npm_ast_grep_bin(shim_path.absolute(), resolved_path)
     if npm_bin is not None:
-        node = shutil.which("node")
-        if node is None:
-            raise ValueError("The @ast-grep/cli launcher requires Node.js, but node was not found")
-        node_path = Path(node).resolve(strict=True)
-        return ResolvedExecutable(path=npm_bin, command_prefix=(str(node_path), str(npm_bin)))
+        if _requires_node(npm_bin):
+            node = shutil.which("node")
+            if node is None:
+                raise ValueError("The @ast-grep/cli launcher requires Node.js, but node was not found")
+            node_path = Path(node).resolve(strict=True)
+            return ResolvedExecutable(path=npm_bin, command_prefix=(str(node_path), str(npm_bin)))
+        if os.name != "nt" and not os.access(npm_bin, os.X_OK):
+            raise ValueError(f"ast-grep executable is not executable: {npm_bin}")
+        return ResolvedExecutable(path=npm_bin, command_prefix=(str(npm_bin),))
 
     if resolved_path.suffix.lower() in {".bat", ".cmd"}:
         raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "sg-mcp"
-version = "0.1.0"
-description = "Add your description here"
+version = "0.2.0"
+description = "A bounded, read-only ast-grep MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pydantic>=2.11.0",
-    "mcp[cli]>=1.6.0",
-    "pyyaml>=6.0.2",
+    "mcp[cli]==1.27.2",
+    "pydantic>=2.11.0,<3",
+    "pyyaml>=6.0.2,<7",
 ]
 
 [project.optional-dependencies]
@@ -15,6 +19,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
+    "pytest-asyncio>=1.0.0",
     "ruff>=0.7.0",
     "mypy>=1.13.0",
     "types-pyyaml>=6.0.12.20250809",
@@ -23,12 +28,16 @@ dev = [
 [project.scripts]
 ast-grep-server = "main:run_mcp_server"
 
+[tool.setuptools]
+py-modules = ["main"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v"
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 source = ["main"]
@@ -49,7 +58,7 @@ line-length = 140
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W"]
+select = ["B", "E", "F", "I", "N", "RUF", "UP", "W"]
 
 [tool.mypy]
 python_version = "3.13"
@@ -57,4 +66,3 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,138 +1,177 @@
-"""Integration tests for ast-grep MCP server"""
+from __future__ import annotations
 
-import json
-import os
+import shutil
 import sys
-from unittest.mock import Mock, patch
+from pathlib import Path
 
 import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 
-# Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from main import AstGrepService, build_runtime
 
-
-# Mock FastMCP to disable decoration
-class MockFastMCP:
-    """Mock FastMCP that returns functions unchanged"""
-
-    def __init__(self, name):
-        self.name = name
-        self.tools = {}  # Store registered tools
-
-    def tool(self, **kwargs):
-        """Decorator that returns the function unchanged"""
-
-        def decorator(func):
-            # Store the function for later retrieval
-            self.tools[func.__name__] = func
-            return func  # Return original function without modification
-
-        return decorator
-
-    def run(self, **kwargs):
-        """Mock run method"""
-        pass
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
-# Mock the Field function to return the default value
-def mock_field(**kwargs):
-    return kwargs.get("default")
+def actual_service(root: Path, *, forbid_regex_rules: bool = False) -> AstGrepService:
+    executable = shutil.which("ast-grep")
+    if executable is None:
+        pytest.fail("ast-grep must be installed for integration tests")
+    runtime = build_runtime(
+        working_directory=root,
+        ast_grep_executable=executable,
+        allowed_roots=[str(root)],
+        forbid_regex_rules=forbid_regex_rules,
+    )
+    assert runtime.ast_grep_version == "0.44.1"
+    return AstGrepService(runtime)
 
 
-# Import with mocked decorators
-with patch("mcp.server.fastmcp.FastMCP", MockFastMCP):
-    with patch("pydantic.Field", mock_field):
-        import main
+def test_pattern_search_is_bounded_and_project_relative() -> None:
+    service = actual_service(REPOSITORY_ROOT)
 
-        # Call register_mcp_tools to define the tool functions
-        main.register_mcp_tools()
+    result = service.find_code(
+        project_folder=str(FIXTURES),
+        pattern="def $NAME($$$): $$$BODY",
+        language="python",
+        paths=["example.py"],
+        include_globs=None,
+        exclude_globs=None,
+        max_results=1,
+    )
 
-        # Extract the tool functions from the mocked mcp instance
-        find_code = main.mcp.tools.get("find_code")
-        find_code_by_rule = main.mcp.tools.get("find_code_by_rule")
+    assert result["returned"] == 1
+    assert result["truncated"] is True
+    assert result["limit"] == 1
+    assert result["matches"][0]["file"] == "example.py"
+    assert "def hello" in result["matches"][0]["text"]
 
 
-@pytest.fixture
-def fixtures_dir():
-    """Get the path to the fixtures directory"""
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "fixtures"))
+def test_rule_search_honors_include_and_exclude_globs(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "keep.py").write_text("print('keep')\n", encoding="utf-8")
+    (source / "skip_test.py").write_text("print('skip')\n", encoding="utf-8")
+    service = actual_service(tmp_path)
+
+    result = service.find_code_by_rule(
+        project_folder=str(tmp_path),
+        rule_yaml="id: print-calls\nlanguage: python\nrule:\n  pattern: print($A)\n",
+        paths=["src"],
+        include_globs=["**/*.py"],
+        exclude_globs=["**/*_test.py"],
+        max_results=10,
+    )
+
+    assert result["returned"] == 1
+    assert result["truncated"] is False
+    assert result["matches"][0]["file"] == "src/keep.py"
 
 
-class TestIntegration:
-    """Integration tests for ast-grep MCP functions"""
+def test_valid_negative_probe_returns_empty_matches() -> None:
+    service = actual_service(REPOSITORY_ROOT)
 
-    def test_find_code_text_format(self, fixtures_dir):
-        """Test find_code with text format"""
-        result = find_code(
-            project_folder=fixtures_dir,
-            pattern="def $NAME($$$)",
-            language="python",
-            output_format="text",
+    matches = service.test_match_code_rule(
+        code="value = 1",
+        rule_yaml="id: no-call\nlanguage: python\nrule:\n  pattern: print($A)\n",
+    )
+
+    assert matches == []
+
+
+def test_regex_policy_rejects_regex_rule_before_ast_grep_runs() -> None:
+    service = actual_service(REPOSITORY_ROOT, forbid_regex_rules=True)
+
+    with pytest.raises(ValueError, match="Regex ast-grep rules are disabled"):
+        service.test_match_code_rule(
+            code="value = 1",
+            rule_yaml="id: regex\nlanguage: python\nrule:\n  regex: value.*\n",
         )
 
-        assert "hello" in result
-        assert "add" in result
-        assert "Found" in result and "matches" in result
 
-    def test_find_code_json_format(self, fixtures_dir):
-        """Test find_code with JSON format"""
-        result = find_code(
-            project_folder=fixtures_dir,
-            pattern="def $NAME($$$)",
-            language="python",
-            output_format="json",
-        )
+@pytest.mark.asyncio
+async def test_stdio_protocol_catalog_annotations_metadata_and_search_contract() -> None:
+    executable = shutil.which("ast-grep")
+    if executable is None:
+        pytest.fail("ast-grep must be installed for protocol tests")
+    parameters = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            str(REPOSITORY_ROOT / "main.py"),
+            "--ast-grep",
+            executable,
+            "--allowed-root",
+            str(REPOSITORY_ROOT),
+            "--forbid-regex-rules",
+        ],
+        cwd=REPOSITORY_ROOT,
+    )
 
-        assert len(result) >= 2
-        assert any("hello" in str(match) for match in result)
-        assert any("add" in str(match) for match in result)
+    async with stdio_client(parameters) as streams:
+        async with ClientSession(*streams) as session:
+            await session.initialize()
+            listed = await session.list_tools()
+            tools = {tool.name: tool for tool in listed.tools}
+            assert set(tools) == {
+                "dump_syntax_tree",
+                "test_match_code_rule",
+                "find_code",
+                "find_code_by_rule",
+                "get_server_info",
+            }
+            for tool in tools.values():
+                assert tool.annotations is not None
+                assert tool.annotations.readOnlyHint is True
+                assert tool.annotations.destructiveHint is False
+                assert tool.annotations.idempotentHint is True
+                assert tool.annotations.openWorldHint is False
 
-    @patch("main.run_ast_grep")
-    def test_find_code_by_rule(self, mock_run, fixtures_dir):
-        """Test find_code_by_rule with mocked ast-grep"""
-        # Mock the response with JSONL format (since we always use --json=stream internally)
-        mock_result = Mock()
-        mock_matches = [
-            {"text": "class Calculator:\n    pass", "file": "fixtures/example.py", "range": {"start": {"line": 6}, "end": {"line": 7}}}
-        ]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
+            find_schema = tools["find_code"].inputSchema
+            assert {"project_folder", "pattern", "language"}.issubset(find_schema["required"])
 
-        yaml_rule = """id: test
-language: python
-rule:
-  pattern: class $NAME"""
+            info_result = await session.call_tool("get_server_info", {})
+            assert info_result.isError is False
+            assert info_result.structuredContent is not None
+            assert info_result.structuredContent["fork_version"] == "0.2.0"
+            assert info_result.structuredContent["ast_grep_version"] == "0.44.1"
+            assert info_result.structuredContent["forbid_regex_rules"] is True
+            assert info_result.structuredContent["default_max_results"] == 50
+            assert info_result.structuredContent["max_results_cap"] == 500
 
-        result = find_code_by_rule(project_folder=fixtures_dir, yaml=yaml_rule, output_format="text")
+            negative = await session.call_tool(
+                "test_match_code_rule",
+                {
+                    "code": "value = 1",
+                    "yaml": "id: no-call\nlanguage: python\nrule:\n  pattern: print($A)\n",
+                },
+            )
+            assert negative.isError is False
+            assert negative.structuredContent == {"result": []}
 
-        assert "Calculator" in result
-        assert "Found 1 match" in result
-        assert "fixtures/example.py:7-8" in result
+            found = await session.call_tool(
+                "find_code",
+                {
+                    "project_folder": str(FIXTURES),
+                    "pattern": "def $NAME($$$): $$$BODY",
+                    "language": "python",
+                    "paths": ["example.py"],
+                    "max_results": 1,
+                    "output_format": "json",
+                },
+            )
+            assert found.isError is False
+            assert found.structuredContent is not None
+            assert set(found.structuredContent) == {"matches", "returned", "truncated", "limit"}
+            assert found.structuredContent["returned"] == 1
+            assert found.structuredContent["truncated"] is True
+            assert found.structuredContent["limit"] == 1
 
-        # Verify the command was called correctly
-        mock_run.assert_called_once_with("scan", ["--inline-rules", yaml_rule, "--json=stream", fixtures_dir])
-
-    def test_find_code_with_max_results(self, fixtures_dir):
-        """Test find_code with max_results parameter"""
-        result = find_code(
-            project_folder=fixtures_dir,
-            pattern="def $NAME($$$)",
-            language="python",
-            max_results=1,
-            output_format="text",
-        )
-
-        # The new format says "showing first X of Y" instead of "limited to X"
-        assert "showing first 1 of" in result or "Found 1 match" in result
-        # Should only have one match in the output
-        assert result.count("def ") == 1
-
-    def test_find_code_no_matches(self, fixtures_dir):
-        """Test find_code when no matches are found"""
-        result = find_code(
-            project_folder=fixtures_dir,
-            pattern="nonexistent_pattern_xyz",
-            output_format="text",
-        )
-
-        assert result == "No matches found"
+            rejected = await session.call_tool(
+                "find_code_by_rule",
+                {
+                    "project_folder": str(FIXTURES),
+                    "yaml": "id: regex\nlanguage: python\nrule:\n  regex: value.*\n",
+                },
+            )
+            assert rejected.isError is True

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,463 +1,466 @@
-"""Unit tests for ast-grep MCP server"""
+from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
-from unittest.mock import Mock, patch
+from pathlib import Path
+from typing import Any
 
 import pytest
 
-# Add the parent directory to the path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from main import (
+    AstGrepService,
+    ResolvedExecutable,
+    ServerRuntime,
+    build_runtime,
+    format_matches_as_text,
+    format_search_results,
+    get_supported_languages,
+    parse_stream_matches,
+    resolve_ast_grep_executable,
+    run_process,
+    validate_rule_yaml,
+)
 
 
-# Mock FastMCP to disable decoration
-class MockFastMCP:
-    """Mock FastMCP that returns functions unchanged"""
+class RecordingRunner:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+        self.calls: list[tuple[list[str], dict[str, Any]]] = []
 
-    def __init__(self, name):
-        self.name = name
-        self.tools = {}  # Store registered tools
-
-    def tool(self, **kwargs):
-        """Decorator that returns the function unchanged"""
-
-        def decorator(func):
-            # Store the function for later retrieval
-            self.tools[func.__name__] = func
-            return func  # Return original function without modification
-
-        return decorator
-
-    def run(self, **kwargs):
-        """Mock run method"""
-        pass
+    def __call__(self, arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        self.calls.append((arguments, kwargs))
+        return subprocess.CompletedProcess(arguments, self.returncode, self.stdout, self.stderr)
 
 
-# Mock the Field function to return the default value
-def mock_field(**kwargs):
-    return kwargs.get("default")
+def make_runtime(
+    root: Path,
+    *,
+    default_max_results: int = 50,
+    max_results_cap: int = 500,
+    forbid_regex_rules: bool = False,
+) -> ServerRuntime:
+    executable = root / "ast-grep-test-executable"
+    executable.write_text("test executable", encoding="utf-8")
+    executable.chmod(0o755)
+    return ServerRuntime(
+        working_directory=root,
+        executable=ResolvedExecutable(path=executable, command_prefix=(str(executable),)),
+        ast_grep_version="0.44.1",
+        config_path=None,
+        allowed_roots=(root,),
+        command_timeout_seconds=2.0,
+        default_max_results=default_max_results,
+        max_results_cap=max_results_cap,
+        forbid_regex_rules=forbid_regex_rules,
+    )
 
 
-# Patch the imports before loading main
-with patch("mcp.server.fastmcp.FastMCP", MockFastMCP):
-    with patch("pydantic.Field", mock_field):
-        import main
-        from main import (
-            format_matches_as_text,
-            parse_matches,
-            run_ast_grep,
-            run_command,
+def version_runner(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(arguments, 0, "ast-grep 0.44.1\n", "")
+
+
+def test_build_runtime_resolves_config_roots_and_version(tmp_path: Path) -> None:
+    executable = tmp_path / "ast-grep"
+    executable.write_text("test executable", encoding="utf-8")
+    executable.chmod(0o755)
+    config = tmp_path / "sgconfig.yml"
+    config.write_text("ruleDirs: []\n", encoding="utf-8")
+
+    runtime = build_runtime(
+        working_directory=tmp_path,
+        ast_grep_executable=str(executable),
+        config_path="sgconfig.yml",
+        allowed_roots=[str(tmp_path), str(tmp_path)],
+        command_timeout_seconds=5,
+        default_max_results=25,
+        max_results_cap=100,
+        forbid_regex_rules=True,
+        runner=version_runner,
+    )
+
+    assert runtime.config_path == config
+    assert runtime.allowed_roots == (tmp_path,)
+    assert runtime.ast_grep_version == "0.44.1"
+    assert runtime.default_max_results == 25
+    assert runtime.max_results_cap == 100
+    assert runtime.forbid_regex_rules is True
+
+
+def test_build_runtime_rejects_missing_executable(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        build_runtime(
+            working_directory=tmp_path,
+            ast_grep_executable=str(tmp_path / "missing"),
         )
 
-        # Call register_mcp_tools to define the tool functions
-        main.register_mcp_tools()
 
-        # Extract the tool functions from the mocked mcp instance
-        dump_syntax_tree = main.mcp.tools.get("dump_syntax_tree")
-        find_code = main.mcp.tools.get("find_code")
-        find_code_by_rule = main.mcp.tools.get("find_code_by_rule")
-        match_code_rule = main.mcp.tools.get("test_match_code_rule")
-
-
-class TestDumpSyntaxTree:
-    """Test the dump_syntax_tree function"""
-
-    @patch("main.run_ast_grep")
-    def test_dump_syntax_tree_cst(self, mock_run):
-        """Test dumping CST format"""
-        mock_result = Mock()
-        mock_result.stderr = "ROOT@0..10"
-        mock_run.return_value = mock_result
-
-        result = dump_syntax_tree("const x = 1", "javascript", "cst")
-
-        assert result == "ROOT@0..10"
-        mock_run.assert_called_once_with(
-            "run",
-            ["--pattern", "const x = 1", "--lang", "javascript", "--debug-query=cst"],
+def test_build_runtime_rejects_wrong_executable(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="is not ast-grep"):
+        build_runtime(
+            working_directory=tmp_path,
+            ast_grep_executable=sys.executable,
         )
 
-    @patch("main.run_ast_grep")
-    def test_dump_syntax_tree_pattern(self, mock_run):
-        """Test dumping pattern format"""
-        mock_result = Mock()
-        mock_result.stderr = "pattern_node"
-        mock_run.return_value = mock_result
 
-        result = dump_syntax_tree("$VAR", "python", "pattern")
+def test_build_runtime_rejects_config_outside_allowed_root(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    config = tmp_path / "outside.yml"
+    config.write_text("ruleDirs: []\n", encoding="utf-8")
+    executable = allowed / "ast-grep"
+    executable.write_text("test executable", encoding="utf-8")
+    executable.chmod(0o755)
 
-        assert result == "pattern_node"
-        mock_run.assert_called_once_with("run", ["--pattern", "$VAR", "--lang", "python", "--debug-query=pattern"])
-
-
-class TestTestMatchCodeRule:
-    """Test the test_match_code_rule function"""
-
-    @patch("main.run_ast_grep")
-    def test_match_found(self, mock_run):
-        """Test when matches are found"""
-        mock_result = Mock()
-        mock_result.stdout = '[{"text": "def foo(): pass"}]'
-        mock_run.return_value = mock_result
-
-        yaml_rule = """id: test
-language: python
-rule:
-  pattern: 'def $NAME(): $$$'
-"""
-        code = "def foo(): pass"
-
-        result = match_code_rule(code, yaml_rule)
-
-        assert result == [{"text": "def foo(): pass"}]
-        mock_run.assert_called_once_with("scan", ["--inline-rules", yaml_rule, "--json", "--stdin"], input_text=code)
-
-    @patch("main.run_ast_grep")
-    def test_no_match(self, mock_run):
-        """Test when no matches are found"""
-        mock_result = Mock()
-        mock_result.stdout = "[]"
-        mock_run.return_value = mock_result
-
-        yaml_rule = """id: test
-language: python
-rule:
-  pattern: 'class $NAME'
-"""
-        code = "def foo(): pass"
-
-        with pytest.raises(ValueError, match="No matches found"):
-            match_code_rule(code, yaml_rule)
+    with pytest.raises(ValueError, match="Config path resolves outside"):
+        build_runtime(
+            working_directory=allowed,
+            ast_grep_executable=str(executable),
+            config_path=str(config),
+            allowed_roots=[str(allowed)],
+            runner=version_runner,
+        )
 
 
-class TestFindCode:
-    """Test the find_code function"""
+@pytest.mark.parametrize(
+    ("default_limit", "cap"),
+    [
+        pytest.param(0, 500, id="zero-default"),
+        pytest.param(51, 50, id="default-over-cap"),
+        pytest.param(1, 0, id="zero-cap"),
+        pytest.param(1, 501, id="cap-over-hard-limit"),
+    ],
+)
+def test_build_runtime_rejects_invalid_limits(tmp_path: Path, default_limit: int, cap: int) -> None:
+    executable = tmp_path / "ast-grep"
+    executable.write_text("test executable", encoding="utf-8")
+    executable.chmod(0o755)
 
-    @patch("main.run_ast_grep")
-    def test_text_format_with_results(self, mock_run):
-        """Test text format output with results"""
-        mock_result = Mock()
-        mock_matches = [
-            {"text": "def foo():\n    pass", "file": "file.py", "range": {"start": {"line": 0}, "end": {"line": 1}}},
-            {"text": "def bar():\n    return", "file": "file.py", "range": {"start": {"line": 4}, "end": {"line": 5}}},
-        ]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
+    with pytest.raises(ValueError):
+        build_runtime(
+            working_directory=tmp_path,
+            ast_grep_executable=str(executable),
+            default_max_results=default_limit,
+            max_results_cap=cap,
+            runner=version_runner,
+        )
 
-        result = find_code(
-            project_folder="/test/path",
-            pattern="def $NAME():",
+
+def test_resolve_ast_grep_executable_uses_node_for_npm_shim(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for this executable-resolution test")
+
+    package = tmp_path / "node_modules" / "@ast-grep" / "cli"
+    package.mkdir(parents=True)
+    target = package / "bin" / "ast-grep.js"
+    target.parent.mkdir()
+    target.write_text("console.log('ast-grep')\n", encoding="utf-8")
+    (package / "package.json").write_text(
+        json.dumps({"name": "@ast-grep/cli", "bin": {"ast-grep": "bin/ast-grep.js"}}),
+        encoding="utf-8",
+    )
+    shim = tmp_path / "node_modules" / ".bin" / "ast-grep"
+    shim.parent.mkdir(parents=True)
+    shim.write_text("shim", encoding="utf-8")
+
+    resolved = resolve_ast_grep_executable(str(shim), working_directory=tmp_path)
+
+    assert resolved.path == target
+    assert resolved.command_prefix == (str(Path(node).resolve()), str(target))
+
+
+def test_resolve_ast_grep_executable_uses_node_for_global_windows_npm_shim(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for this executable-resolution test")
+
+    package = tmp_path / "node_modules" / "@ast-grep" / "cli"
+    package.mkdir(parents=True)
+    target = package / "ast-grep.js"
+    target.write_text("console.log('ast-grep')\n", encoding="utf-8")
+    (package / "package.json").write_text(
+        json.dumps({"name": "@ast-grep/cli", "bin": "ast-grep.js"}),
+        encoding="utf-8",
+    )
+    shim = tmp_path / "ast-grep.cmd"
+    shim.write_text("@echo off\n", encoding="utf-8")
+
+    resolved = resolve_ast_grep_executable(str(shim), working_directory=tmp_path)
+
+    assert resolved.path == target
+    assert resolved.command_prefix == (str(Path(node).resolve()), str(target))
+
+
+def test_run_process_reports_timeout() -> None:
+    def timeout_runner(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(arguments, timeout=1)
+
+    with pytest.raises(RuntimeError, match="timed out after 1 seconds"):
+        run_process(["ast-grep", "--version"], timeout_seconds=1, runner=timeout_runner)
+
+
+def test_parse_stream_matches_rejects_non_json_output() -> None:
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        parse_stream_matches("not json")
+
+
+def test_validate_rule_yaml_accepts_structural_rule_and_negative_probe_shape() -> None:
+    validate_rule_yaml(
+        "id: calls\nlanguage: python\nrule:\n  pattern: print($A)\n",
+        forbid_regex_rules=True,
+    )
+
+
+def test_validate_rule_yaml_rejects_regex_matcher_when_policy_enabled() -> None:
+    with pytest.raises(ValueError, match="Regex ast-grep rules are disabled"):
+        validate_rule_yaml(
+            "id: text\nlanguage: python\nrule:\n  regex: secret.*\n",
+            forbid_regex_rules=True,
+        )
+
+
+def test_validate_rule_yaml_allows_regex_matcher_when_policy_disabled() -> None:
+    validate_rule_yaml(
+        "id: text\nlanguage: python\nrule:\n  regex: secret.*\n",
+        forbid_regex_rules=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_yaml",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("- item\n", id="not-a-mapping"),
+        pytest.param("id: missing-fields\n", id="missing-fields"),
+        pytest.param("id: wrong-rule\nlanguage: python\nrule: value\n", id="rule-not-mapping"),
+    ],
+)
+def test_validate_rule_yaml_rejects_invalid_shapes(rule_yaml: str) -> None:
+    with pytest.raises(ValueError):
+        validate_rule_yaml(rule_yaml, forbid_regex_rules=False)
+
+
+def test_get_supported_languages_reads_custom_languages(tmp_path: Path) -> None:
+    config = tmp_path / "sgconfig.yml"
+    config.write_text("customLanguages:\n  templ: {}\n", encoding="utf-8")
+
+    languages = get_supported_languages(config)
+
+    assert "python" in languages
+    assert "templ" in languages
+
+
+def test_search_rejects_project_outside_allowed_root(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    service = AstGrepService(make_runtime(allowed))
+
+    with pytest.raises(ValueError, match="Project folder resolves outside"):
+        service.find_code(
+            project_folder=str(outside),
+            pattern="print($A)",
             language="python",
-            output_format="text",
-        )
-
-        assert "Found 2 matches:" in result
-        assert "def foo():" in result
-        assert "def bar():" in result
-        assert "file.py:1-2" in result
-        assert "file.py:5-6" in result
-        mock_run.assert_called_once_with("run", ["--pattern", "def $NAME():", "--lang", "python", "--json=stream", "/test/path"])
-
-    @patch("main.run_ast_grep")
-    def test_text_format_no_results(self, mock_run):
-        """Test text format output with no results"""
-        mock_result = Mock()
-        mock_result.stdout = ""
-        mock_run.return_value = mock_result
-
-        result = find_code(project_folder="/test/path", pattern="nonexistent", output_format="text")
-
-        assert result == "No matches found"
-        mock_run.assert_called_once_with("run", ["--pattern", "nonexistent", "--json=stream", "/test/path"])
-
-    @patch("main.run_ast_grep")
-    def test_text_format_with_max_results(self, mock_run):
-        """Test text format with max_results limit"""
-        mock_result = Mock()
-        mock_matches = [
-            {"text": "match1", "file": "f.py", "range": {"start": {"line": 0}, "end": {"line": 0}}},
-            {"text": "match2", "file": "f.py", "range": {"start": {"line": 1}, "end": {"line": 1}}},
-            {"text": "match3", "file": "f.py", "range": {"start": {"line": 2}, "end": {"line": 2}}},
-            {"text": "match4", "file": "f.py", "range": {"start": {"line": 3}, "end": {"line": 3}}},
-        ]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
-
-        result = find_code(
-            project_folder="/test/path",
-            pattern="pattern",
-            max_results=2,
-            output_format="text",
-        )
-
-        assert "Found 2 matches (showing first 2 of 4):" in result
-        assert "match1" in result
-        assert "match2" in result
-        assert "match3" not in result
-
-    @patch("main.run_ast_grep")
-    def test_json_format(self, mock_run):
-        """Test JSON format output"""
-        mock_result = Mock()
-        mock_matches = [
-            {"text": "def foo():", "file": "test.py"},
-            {"text": "def bar():", "file": "test.py"},
-        ]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
-
-        result = find_code(project_folder="/test/path", pattern="def $NAME():", output_format="json")
-
-        assert result == mock_matches
-        mock_run.assert_called_once_with("run", ["--pattern", "def $NAME():", "--json=stream", "/test/path"])
-
-    @patch("main.run_ast_grep")
-    def test_json_format_with_max_results(self, mock_run):
-        """Test JSON format with max_results limit"""
-        mock_result = Mock()
-        mock_matches = [{"text": "match1"}, {"text": "match2"}, {"text": "match3"}]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
-
-        result = find_code(
-            project_folder="/test/path",
-            pattern="pattern",
-            max_results=2,
-            output_format="json",
-        )
-
-        assert len(result) == 2
-        assert result[0]["text"] == "match1"
-        assert result[1]["text"] == "match2"
-
-    def test_invalid_output_format(self):
-        """Test with invalid output format"""
-        with pytest.raises(ValueError, match="Invalid output_format"):
-            find_code(project_folder="/test/path", pattern="pattern", output_format="invalid")
-
-
-class TestFindCodeByRule:
-    """Test the find_code_by_rule function"""
-
-    @patch("main.run_ast_grep")
-    def test_text_format_with_results(self, mock_run):
-        """Test text format output with results"""
-        mock_result = Mock()
-        mock_matches = [
-            {"text": "class Foo:\n    pass", "file": "file.py", "range": {"start": {"line": 0}, "end": {"line": 1}}},
-            {"text": "class Bar:\n    pass", "file": "file.py", "range": {"start": {"line": 9}, "end": {"line": 10}}},
-        ]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
-
-        yaml_rule = """id: test
-language: python
-rule:
-  pattern: 'class $NAME'
-"""
-
-        result = find_code_by_rule(project_folder="/test/path", yaml=yaml_rule, output_format="text")
-
-        assert "Found 2 matches:" in result
-        assert "class Foo:" in result
-        assert "class Bar:" in result
-        assert "file.py:1-2" in result
-        assert "file.py:10-11" in result
-        mock_run.assert_called_once_with("scan", ["--inline-rules", yaml_rule, "--json=stream", "/test/path"])
-
-    @patch("main.run_ast_grep")
-    def test_json_format(self, mock_run):
-        """Test JSON format output"""
-        mock_result = Mock()
-        mock_matches = [{"text": "class Foo:", "file": "test.py"}]
-        mock_result.stdout = "\n".join(json.dumps(m) for m in mock_matches)
-        mock_run.return_value = mock_result
-
-        yaml_rule = """id: test
-language: python
-rule:
-  pattern: 'class $NAME'
-"""
-
-        result = find_code_by_rule(project_folder="/test/path", yaml=yaml_rule, output_format="json")
-
-        assert result == mock_matches
-        mock_run.assert_called_once_with("scan", ["--inline-rules", yaml_rule, "--json=stream", "/test/path"])
-
-
-class TestRunCommand:
-    """Test the run_command function"""
-
-    @patch("subprocess.run")
-    def test_successful_command(self, mock_run):
-        """Test successful command execution"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stdout = "output"
-        mock_run.return_value = mock_result
-
-        result = run_command(["echo", "test"])
-
-        assert result.stdout == "output"
-        mock_run.assert_called_once_with(["echo", "test"], capture_output=True, input=None, text=True, check=True, shell=False)
-
-    @patch("subprocess.run")
-    def test_command_failure(self, mock_run):
-        """Test command execution failure"""
-        mock_run.side_effect = subprocess.CalledProcessError(1, ["false"], stderr="error message")
-
-        with pytest.raises(Exception, match="failed with exit code 1"):
-            run_command(["false"])
-
-    @patch("subprocess.run")
-    def test_command_not_found(self, mock_run):
-        """Test when command is not found"""
-        mock_run.side_effect = FileNotFoundError()
-
-        with pytest.raises(RuntimeError, match="not found"):
-            run_command(["nonexistent"])
-
-
-class TestFormatMatchesAsText:
-    """Test the format_matches_as_text helper function"""
-
-    def test_empty_matches(self):
-        """Test with empty matches list"""
-        result = format_matches_as_text([])
-        assert result == ""
-
-    def test_single_line_match(self):
-        """Test formatting a single-line match"""
-        matches = [{"text": "const x = 1", "file": "test.js", "range": {"start": {"line": 4}, "end": {"line": 4}}}]
-        result = format_matches_as_text(matches)
-        assert result == "test.js:5\nconst x = 1"
-
-    def test_multi_line_match(self):
-        """Test formatting a multi-line match"""
-        matches = [{"text": "def foo():\n    return 42", "file": "test.py", "range": {"start": {"line": 9}, "end": {"line": 10}}}]
-        result = format_matches_as_text(matches)
-        assert result == "test.py:10-11\ndef foo():\n    return 42"
-
-    def test_multiple_matches(self):
-        """Test formatting multiple matches"""
-        matches = [
-            {"text": "match1", "file": "file1.py", "range": {"start": {"line": 0}, "end": {"line": 0}}},
-            {"text": "match2\nline2", "file": "file2.py", "range": {"start": {"line": 5}, "end": {"line": 6}}},
-        ]
-        result = format_matches_as_text(matches)
-        expected = "file1.py:1\nmatch1\n\nfile2.py:6-7\nmatch2\nline2"
-        assert result == expected
-
-
-class TestParseMatches:
-    """Test the parse_matches helper function"""
-
-    def test_empty_input(self):
-        """Test with empty string"""
-        matches, total = parse_matches("")
-        assert matches == []
-        assert total == 0
-
-    def test_normal_parsing(self):
-        """Test parsing JSONL output"""
-        lines = [
-            json.dumps({"text": "match1", "file": "a.py"}),
-            json.dumps({"text": "match2", "file": "b.py"}),
-        ]
-        matches, total = parse_matches("\n".join(lines))
-        assert len(matches) == 2
-        assert total == 2
-        assert matches[0]["text"] == "match1"
-        assert matches[1]["text"] == "match2"
-
-    def test_early_exit_with_max_results(self):
-        """Test that max_results limits parsed matches but counts all lines"""
-        lines = [
-            json.dumps({"text": f"match{i}"}) for i in range(5)
-        ]
-        matches, total = parse_matches("\n".join(lines), max_results=2)
-        assert len(matches) == 2
-        assert total == 5
-        assert matches[0]["text"] == "match0"
-        assert matches[1]["text"] == "match1"
-
-    def test_blank_lines_ignored(self):
-        """Test that blank lines are skipped"""
-        lines = [
-            json.dumps({"text": "match1"}),
-            "",
-            "  ",
-            json.dumps({"text": "match2"}),
-        ]
-        matches, total = parse_matches("\n".join(lines))
-        assert len(matches) == 2
-        assert total == 2
-
-    def test_non_json_lines_skipped(self):
-        """Test that non-JSON lines (e.g. warnings) are skipped without crashing"""
-        lines = [
-            "WARNING: some ast-grep warning",
-            json.dumps({"text": "match1"}),
-            "another warning line",
-            json.dumps({"text": "match2"}),
-        ]
-        matches, total = parse_matches("\n".join(lines))
-        assert len(matches) == 2
-        assert total == 2
-        assert matches[0]["text"] == "match1"
-
-    def test_non_json_lines_not_counted_with_max_results(self):
-        """Test that warning lines after max_results don't inflate total count"""
-        lines = [
-            json.dumps({"text": "match1"}),
-            json.dumps({"text": "match2"}),
-            "WARNING: something",
-            json.dumps({"text": "match3"}),
-        ]
-        matches, total = parse_matches("\n".join(lines), max_results=1)
-        assert len(matches) == 1
-        assert total == 3  # only JSON lines counted
-
-
-class TestRunAstGrep:
-    """Test the run_ast_grep function"""
-
-    @patch("main.run_command")
-    @patch("main.CONFIG_PATH", None)
-    def test_without_config(self, mock_run):
-        """Test running ast-grep without config"""
-        mock_result = Mock()
-        mock_run.return_value = mock_result
-
-        result = run_ast_grep("run", ["--pattern", "test"])
-
-        assert result == mock_result
-        mock_run.assert_called_once_with(["ast-grep", "run", "--pattern", "test"], None)
-
-    @patch("main.run_command")
-    @patch("main.CONFIG_PATH", "/path/to/config.yaml")
-    def test_with_config(self, mock_run):
-        """Test running ast-grep with config"""
-        mock_result = Mock()
-        mock_run.return_value = mock_result
-
-        result = run_ast_grep("scan", ["--inline-rules", "rule"])
-
-        assert result == mock_result
-        mock_run.assert_called_once_with(
-            [
-                "ast-grep",
-                "scan",
-                "--config",
-                "/path/to/config.yaml",
-                "--inline-rules",
-                "rule",
-            ],
-            None,
+            paths=None,
+            include_globs=None,
+            exclude_globs=None,
+            max_results=1,
         )
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+def test_search_rejects_parent_path_escape(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    service = AstGrepService(make_runtime(tmp_path))
+
+    with pytest.raises(ValueError, match="outside project_folder"):
+        service.find_code(
+            project_folder="project",
+            pattern="print($A)",
+            language="python",
+            paths=["../outside.py"],
+            include_globs=None,
+            exclude_globs=None,
+            max_results=1,
+        )
+
+
+def test_search_rejects_absolute_search_path(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    source = project / "example.py"
+    source.write_text("print('value')\n", encoding="utf-8")
+    service = AstGrepService(make_runtime(tmp_path))
+
+    with pytest.raises(ValueError, match="must be relative"):
+        service.find_code(
+            project_folder="project",
+            pattern="print($A)",
+            language="python",
+            paths=[str(source)],
+            include_globs=None,
+            exclude_globs=None,
+            max_results=1,
+        )
+
+
+def test_search_rejects_symlink_escape(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    link = project / "linked.py"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"Symlinks are unavailable: {error}")
+    service = AstGrepService(make_runtime(tmp_path))
+
+    with pytest.raises(ValueError, match="outside project_folder"):
+        service.find_code(
+            project_folder="project",
+            pattern="print($A)",
+            language="python",
+            paths=["linked.py"],
+            include_globs=None,
+            exclude_globs=None,
+            max_results=1,
+        )
+
+
+def test_search_uses_limit_plus_one_globs_and_relative_results(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    source = project / "src" / "example.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print('one')\nprint('two')\n", encoding="utf-8")
+    matches = [
+        {
+            "file": str(source),
+            "text": "print('one')",
+            "range": {"start": {"line": 0}, "end": {"line": 0}},
+        },
+        {
+            "file": str(source),
+            "text": "print('two')",
+            "range": {"start": {"line": 1}, "end": {"line": 1}},
+        },
+    ]
+    runner = RecordingRunner(stdout="\n".join(json.dumps(match) for match in matches))
+    service = AstGrepService(make_runtime(tmp_path), runner=runner)
+
+    results = service.find_code(
+        project_folder="project",
+        pattern="print($A)",
+        language="python",
+        paths=["src"],
+        include_globs=["*.py"],
+        exclude_globs=["*_test.py"],
+        max_results=1,
+    )
+
+    assert results == {
+        "matches": [
+            {
+                "file": "src/example.py",
+                "text": "print('one')",
+                "range": {"start": {"line": 0}, "end": {"line": 0}},
+            }
+        ],
+        "returned": 1,
+        "truncated": True,
+        "limit": 1,
+    }
+    command = runner.calls[0][0]
+    assert command[1] == "scan"
+    assert command[command.index("--max-results") + 1] == "2"
+    assert [command[index + 1] for index, value in enumerate(command) if value == "--globs"] == ["*.py", "!*_test.py"]
+    assert command[-1] == str(source.parent)
+
+
+def test_search_rejects_zero_and_unlimited_limits(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    service = AstGrepService(make_runtime(tmp_path))
+
+    with pytest.raises(ValueError, match="between 1 and 500"):
+        service.find_code(
+            project_folder="project",
+            pattern="print($A)",
+            language="python",
+            paths=None,
+            include_globs=None,
+            exclude_globs=None,
+            max_results=0,
+        )
+
+
+def test_negative_rule_probe_returns_empty_list(tmp_path: Path) -> None:
+    runner = RecordingRunner(stdout="")
+    service = AstGrepService(make_runtime(tmp_path), runner=runner)
+
+    matches = service.test_match_code_rule(
+        code="value = 1",
+        rule_yaml="id: no-call\nlanguage: python\nrule:\n  pattern: print($A)\n",
+    )
+
+    assert matches == []
+    command = runner.calls[0][0]
+    assert command[1] == "scan"
+    assert "--stdin" in command
+    assert command[command.index("--max-results") + 1] == "500"
+
+
+def test_search_exit_one_with_error_is_not_treated_as_no_match(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    runner = RecordingRunner(stderr="invalid rule", returncode=1)
+    service = AstGrepService(make_runtime(tmp_path), runner=runner)
+
+    with pytest.raises(RuntimeError, match="search failed"):
+        service.find_code(
+            project_folder="project",
+            pattern="print($A)",
+            language="python",
+            paths=None,
+            include_globs=None,
+            exclude_globs=None,
+            max_results=1,
+        )
+
+
+def test_format_matches_and_truncation_header() -> None:
+    matches = [
+        {
+            "file": "src/example.py",
+            "text": "print('one')",
+            "range": {"start": {"line": 4}, "end": {"line": 4}},
+        }
+    ]
+
+    assert format_matches_as_text(matches) == "src/example.py:5\nprint('one')"
+    assert (
+        format_search_results({"matches": matches, "returned": 1, "truncated": True, "limit": 1})
+        == "Found 1 match (limit 1; additional matches exist):\n\nsrc/example.py:5\nprint('one')"
+    )
+
+
+def test_server_info_exposes_effective_contract(tmp_path: Path) -> None:
+    runtime = make_runtime(tmp_path, default_max_results=25, max_results_cap=100, forbid_regex_rules=True)
+
+    info = AstGrepService(runtime).get_server_info()
+
+    assert info["fork_version"] == "0.2.0"
+    assert info["ast_grep_version"] == "0.44.1"
+    assert info["allowed_roots"] == [str(tmp_path)]
+    assert info["default_max_results"] == 25
+    assert info["max_results_cap"] == 100
+    assert info["forbid_regex_rules"] is True
+    assert os.path.isabs(info["ast_grep_executable"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -196,6 +196,26 @@ def test_resolve_ast_grep_executable_uses_node_for_global_windows_npm_shim(tmp_p
     assert resolved.command_prefix == (str(Path(node).resolve()), str(target))
 
 
+def test_resolve_ast_grep_executable_runs_native_npm_target_directly(tmp_path: Path) -> None:
+    package = tmp_path / "node_modules" / "@ast-grep" / "cli"
+    package.mkdir(parents=True)
+    target = package / "ast-grep"
+    target.write_bytes(b"\x7fELF test binary")
+    target.chmod(0o755)
+    (package / "package.json").write_text(
+        json.dumps({"name": "@ast-grep/cli", "bin": "ast-grep"}),
+        encoding="utf-8",
+    )
+    shim = tmp_path / "node_modules" / ".bin" / "ast-grep"
+    shim.parent.mkdir(parents=True)
+    shim.write_text("shim", encoding="utf-8")
+
+    resolved = resolve_ast_grep_executable(str(shim), working_directory=tmp_path)
+
+    assert resolved.path == target
+    assert resolved.command_prefix == (str(target),)
+
+
 def test_run_process_reports_timeout() -> None:
     def timeout_runner(arguments: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(arguments, timeout=1)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -25,12 +34,94 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -108,6 +199,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -172,6 +313,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -185,21 +353,27 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "httpx-sse" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031, upload-time = "2025-03-27T16:46:32.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077, upload-time = "2025-03-27T16:46:29.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [package.optional-dependencies]
@@ -280,6 +454,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -345,6 +528,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -358,6 +555,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -396,6 +605,31 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -413,6 +647,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +670,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -452,8 +780,8 @@ wheels = [
 
 [[package]]
 name = "sg-mcp"
-version = "0.1.0"
-source = { virtual = "." }
+version = "0.2.0"
+source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -464,6 +792,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -472,13 +801,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.27.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
-    { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pydantic", specifier = ">=2.11.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250809" },
 ]
@@ -529,17 +859,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.15.2"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711, upload-time = "2025-02-27T19:17:34.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061, upload-time = "2025-02-27T19:17:32.111Z" },
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
 ]
 
 [[package]]
@@ -562,14 +892,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload-time = "2025-02-25T17:27:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- constrain project and search paths to configured real roots, including symlink escape checks
- resolve the ast-grep executable explicitly and add command timeouts, globs, finite result limits, and true early termination
- return structured bounded-search metadata, preserve valid empty negative probes, and expose get_server_info
- annotate every tool as read-only, non-destructive, idempotent, and closed-world
- add an optional policy that rejects regex rule fields without adding a rewrite tool

## Compatibility

find_code now requires an explicit language. MCP searches require finite limits; exhaustive scans remain a CLI responsibility. JSON search output is wrapped as matches, returned, truncated, and limit.

## Verification

- Ruff lint and format
- mypy
- 36 unit and integration tests, including protocol-level STDIO checks
- GitHub Actions passed on Linux, macOS, and Windows: https://github.com/jmclaughlin724/ast-grep-mcp/actions/runs/29537404523